### PR TITLE
Added missing liberty header files.  Equivalent change to what was done on mcu7t5v0.

### DIFF
--- a/liberty/gf180mcu_fd_sc_mcu9t5v0__ff_125C_1v98.lib
+++ b/liberty/gf180mcu_fd_sc_mcu9t5v0__ff_125C_1v98.lib
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 GlobalFoundries PDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+library(gf180mcu_fd_sc_mcu9t5v0__ff_125C_1v98) { 
+  delay_model : table_lookup ; 
+  library_features(report_delay_calculation, report_power_calculation);
+  time_unit : 1ns ; 
+  voltage_unit : 1V ; 
+  current_unit : 1mA ; 
+  capacitive_load_unit(1, pf);
+  pulling_resistance_unit : 1ohm ; 
+  leakage_power_unit : 1uW ; 
+  input_threshold_pct_fall : 50 ; 
+  input_threshold_pct_rise : 50 ; 
+  output_threshold_pct_fall : 50 ; 
+  output_threshold_pct_rise : 50 ; 
+  slew_derate_from_library : 0.5 ; 
+  slew_lower_threshold_pct_fall : 30 ; 
+  slew_lower_threshold_pct_rise : 30 ; 
+  slew_upper_threshold_pct_fall : 70 ; 
+  slew_upper_threshold_pct_rise : 70 ; 
+  nom_process : 1 ; 
+  nom_temperature : 125 ; 
+  nom_voltage : 1.98 ; 
+  voltage_map(VNW, 1.98);
+  voltage_map(VDD, 1.98);
+  voltage_map(VSS, 0);
+  voltage_map(VPW, 0);
+
+  operating_conditions(gf180mcu_fd_sc_mcu9t5v0__ff_125C_1v98) { 
+    process : 1 ; 
+    temperature : 125 ; 
+    voltage : 1.98 ; 
+  }
+
+  input_voltage(default) { 
+    vil : 0 ; 
+    vih : 1.98 ; 
+    vimin : 0 ; 
+    vimax : 1.98 ; 
+  }
+
+  output_voltage(default) { 
+    vol : 0 ; 
+    voh : 1.98 ; 
+    vomin : 0 ; 
+    vomax : 1.98 ; 
+  }
+
+  lu_table_template(cnst_ctin_rtin_10x10) { 
+    variable_1 : constrained_pin_transition ; 
+    variable_2 : related_pin_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(ndw_ntin_nvolt_10x13) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : normalized_voltage ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13");
+  }
+
+  lu_table_template(tmg_ntin_10) { 
+    variable_1 : input_net_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(tmg_ntin_oload_10x10) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_10) { 
+    variable_1 : input_transition_time ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_oload_10x10) { 
+    variable_1 : input_transition_time ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_fall" ; 
+    index_1("0.02, 0.07784, 0.2809, 0.6686, 1.273, 2.12, 3.235, 4.64, 6.356, 8.4");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.00973, 0.01946, 0.02919, 0.03892, 0.04865, 0.05838, 0.06811, 0.07784, 0.08757, 0.0973, 0.107, 0.1168",\
+           "0, 0.03511, 0.07022, 0.1053, 0.1404, 0.1755, 0.2107, 0.2458, 0.2809, 0.316, 0.3511, 0.3862, 0.4213",\
+           "0, 0.08357, 0.1671, 0.2507, 0.3343, 0.4179, 0.5014, 0.585, 0.6686, 0.7522, 0.8357, 0.9193, 1.003",\
+           "0, 0.1591, 0.3182, 0.4772, 0.6363, 0.7954, 0.9545, 1.114, 1.273, 1.432, 1.591, 1.75, 1.909",\
+           "0, 0.265, 0.53, 0.7951, 1.06, 1.325, 1.59, 1.855, 2.12, 2.385, 2.65, 2.915, 3.18",\
+           "0, 0.4044, 0.8089, 1.213, 1.618, 2.022, 2.427, 2.831, 3.235, 3.64, 4.044, 4.449, 4.853",\
+           "0, 0.5801, 1.16, 1.74, 2.32, 2.9, 3.48, 4.06, 4.64, 5.22, 5.801, 6.381, 6.961",\
+           "0, 0.7945, 1.589, 2.383, 3.178, 3.972, 4.767, 5.561, 6.356, 7.15, 7.945, 8.739, 9.533",\
+           "0, 1.05, 2.1, 3.15, 4.2, 5.25, 6.3, 7.35, 8.4, 9.45, 10.5, 11.55, 12.6");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_rise" ; 
+    index_1("0.02, 0.07784, 0.2809, 0.6686, 1.273, 2.12, 3.235, 4.64, 6.356, 8.4");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.00973, 0.01946, 0.02919, 0.03892, 0.04865, 0.05838, 0.06811, 0.07784, 0.08757, 0.0973, 0.107, 0.1168",\
+           "0, 0.03511, 0.07022, 0.1053, 0.1404, 0.1755, 0.2107, 0.2458, 0.2809, 0.316, 0.3511, 0.3862, 0.4213",\
+           "0, 0.08357, 0.1671, 0.2507, 0.3343, 0.4179, 0.5014, 0.585, 0.6686, 0.7522, 0.8357, 0.9193, 1.003",\
+           "0, 0.1591, 0.3182, 0.4772, 0.6363, 0.7954, 0.9545, 1.114, 1.273, 1.432, 1.591, 1.75, 1.909",\
+           "0, 0.265, 0.53, 0.7951, 1.06, 1.325, 1.59, 1.855, 2.12, 2.385, 2.65, 2.915, 3.18",\
+           "0, 0.4044, 0.8089, 1.213, 1.618, 2.022, 2.427, 2.831, 3.235, 3.64, 4.044, 4.449, 4.853",\
+           "0, 0.5801, 1.16, 1.74, 2.32, 2.9, 3.48, 4.06, 4.64, 5.22, 5.801, 6.381, 6.961",\
+           "0, 0.7945, 1.589, 2.383, 3.178, 3.972, 4.767, 5.561, 6.356, 7.15, 7.945, 8.739, 9.533",\
+           "0, 1.05, 2.1, 3.15, 4.2, 5.25, 6.3, 7.35, 8.4, 9.45, 10.5, 11.55, 12.6");
+  }
+}

--- a/liberty/gf180mcu_fd_sc_mcu9t5v0__ff_125C_3v60.lib
+++ b/liberty/gf180mcu_fd_sc_mcu9t5v0__ff_125C_3v60.lib
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 GlobalFoundries PDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+library(gf180mcu_fd_sc_mcu9t5v0__ff_125C_3v60) { 
+  delay_model : table_lookup ; 
+  library_features(report_delay_calculation, report_power_calculation);
+  time_unit : 1ns ; 
+  voltage_unit : 1V ; 
+  current_unit : 1mA ; 
+  capacitive_load_unit(1, pf);
+  pulling_resistance_unit : 1ohm ; 
+  leakage_power_unit : 1uW ; 
+  input_threshold_pct_fall : 50 ; 
+  input_threshold_pct_rise : 50 ; 
+  output_threshold_pct_fall : 50 ; 
+  output_threshold_pct_rise : 50 ; 
+  slew_derate_from_library : 0.5 ; 
+  slew_lower_threshold_pct_fall : 30 ; 
+  slew_lower_threshold_pct_rise : 30 ; 
+  slew_upper_threshold_pct_fall : 70 ; 
+  slew_upper_threshold_pct_rise : 70 ; 
+  nom_process : 1 ; 
+  nom_temperature : 125 ; 
+  nom_voltage : 3.6 ; 
+  voltage_map(VNW, 3.6);
+  voltage_map(VDD, 3.6);
+  voltage_map(VSS, 0);
+  voltage_map(VPW, 0);
+
+  operating_conditions(gf180mcu_fd_sc_mcu9t5v0__ff_125C_3v60) { 
+    process : 1 ; 
+    temperature : 125 ; 
+    voltage : 3.6 ; 
+  }
+
+  input_voltage(default) { 
+    vil : 0 ; 
+    vih : 3.6 ; 
+    vimin : 0 ; 
+    vimax : 3.6 ; 
+  }
+
+  output_voltage(default) { 
+    vol : 0 ; 
+    voh : 3.6 ; 
+    vomin : 0 ; 
+    vomax : 3.6 ; 
+  }
+
+  lu_table_template(cnst_ctin_rtin_10x10) { 
+    variable_1 : constrained_pin_transition ; 
+    variable_2 : related_pin_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(ndw_ntin_nvolt_10x13) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : normalized_voltage ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13");
+  }
+
+  lu_table_template(tmg_ntin_10) { 
+    variable_1 : input_net_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(tmg_ntin_oload_10x10) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_10) { 
+    variable_1 : input_transition_time ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_oload_10x10) { 
+    variable_1 : input_transition_time ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_fall" ; 
+    index_1("0.02, 0.05575, 0.1813, 0.4209, 0.7943, 1.318, 2.008, 2.876, 3.936, 5.2");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.006969, 0.01394, 0.02091, 0.02788, 0.03485, 0.04181, 0.04878, 0.05575, 0.06272, 0.06969, 0.07666, 0.08363",\
+           "0, 0.02266, 0.04531, 0.06797, 0.09063, 0.1133, 0.1359, 0.1586, 0.1813, 0.2039, 0.2266, 0.2492, 0.2719",\
+           "0, 0.05261, 0.1052, 0.1578, 0.2105, 0.2631, 0.3157, 0.3683, 0.4209, 0.4735, 0.5261, 0.5788, 0.6314",\
+           "0, 0.09929, 0.1986, 0.2979, 0.3971, 0.4964, 0.5957, 0.695, 0.7943, 0.8936, 0.9929, 1.092, 1.191",\
+           "0, 0.1648, 0.3295, 0.4943, 0.6591, 0.8239, 0.9886, 1.153, 1.318, 1.483, 1.648, 1.813, 1.977",\
+           "0, 0.2509, 0.5019, 0.7528, 1.004, 1.255, 1.506, 1.757, 2.008, 2.259, 2.509, 2.76, 3.011",\
+           "0, 0.3595, 0.719, 1.079, 1.438, 1.798, 2.157, 2.517, 2.876, 3.236, 3.595, 3.955, 4.314",\
+           "0, 0.492, 0.9841, 1.476, 1.968, 2.46, 2.952, 3.444, 3.936, 4.428, 4.92, 5.412, 5.904",\
+           "0, 0.65, 1.3, 1.95, 2.6, 3.25, 3.9, 4.55, 5.2, 5.85, 6.5, 7.15, 7.8");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_rise" ; 
+    index_1("0.02, 0.05575, 0.1813, 0.4209, 0.7943, 1.318, 2.008, 2.876, 3.936, 5.2");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.006969, 0.01394, 0.02091, 0.02788, 0.03485, 0.04181, 0.04878, 0.05575, 0.06272, 0.06969, 0.07666, 0.08363",\
+           "0, 0.02266, 0.04531, 0.06797, 0.09063, 0.1133, 0.1359, 0.1586, 0.1813, 0.2039, 0.2266, 0.2492, 0.2719",\
+           "0, 0.05261, 0.1052, 0.1578, 0.2105, 0.2631, 0.3157, 0.3683, 0.4209, 0.4735, 0.5261, 0.5788, 0.6314",\
+           "0, 0.09929, 0.1986, 0.2979, 0.3971, 0.4964, 0.5957, 0.695, 0.7943, 0.8936, 0.9929, 1.092, 1.191",\
+           "0, 0.1648, 0.3295, 0.4943, 0.6591, 0.8239, 0.9886, 1.153, 1.318, 1.483, 1.648, 1.813, 1.977",\
+           "0, 0.2509, 0.5019, 0.7528, 1.004, 1.255, 1.506, 1.757, 2.008, 2.259, 2.509, 2.76, 3.011",\
+           "0, 0.3595, 0.719, 1.079, 1.438, 1.798, 2.157, 2.517, 2.876, 3.236, 3.595, 3.955, 4.314",\
+           "0, 0.492, 0.9841, 1.476, 1.968, 2.46, 2.952, 3.444, 3.936, 4.428, 4.92, 5.412, 5.904",\
+           "0, 0.65, 1.3, 1.95, 2.6, 3.25, 3.9, 4.55, 5.2, 5.85, 6.5, 7.15, 7.8");
+  }
+}

--- a/liberty/gf180mcu_fd_sc_mcu9t5v0__ff_125C_5v50.lib
+++ b/liberty/gf180mcu_fd_sc_mcu9t5v0__ff_125C_5v50.lib
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 GlobalFoundries PDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+library(gf180mcu_fd_sc_mcu9t5v0__ff_125C_5v50) { 
+  delay_model : table_lookup ; 
+  library_features(report_delay_calculation, report_power_calculation);
+  time_unit : 1ns ; 
+  voltage_unit : 1V ; 
+  current_unit : 1mA ; 
+  capacitive_load_unit(1, pf);
+  pulling_resistance_unit : 1ohm ; 
+  leakage_power_unit : 1uW ; 
+  input_threshold_pct_fall : 50 ; 
+  input_threshold_pct_rise : 50 ; 
+  output_threshold_pct_fall : 50 ; 
+  output_threshold_pct_rise : 50 ; 
+  slew_derate_from_library : 0.5 ; 
+  slew_lower_threshold_pct_fall : 30 ; 
+  slew_lower_threshold_pct_rise : 30 ; 
+  slew_upper_threshold_pct_fall : 70 ; 
+  slew_upper_threshold_pct_rise : 70 ; 
+  nom_process : 1 ; 
+  nom_temperature : 125 ; 
+  nom_voltage : 5.5 ; 
+  voltage_map(VNW, 5.5);
+  voltage_map(VDD, 5.5);
+  voltage_map(VSS, 0);
+  voltage_map(VPW, 0);
+
+  operating_conditions(gf180mcu_fd_sc_mcu9t5v0__ff_125C_5v50) { 
+    process : 1 ; 
+    temperature : 125 ; 
+    voltage : 5.5 ; 
+  }
+
+  input_voltage(default) { 
+    vil : 0 ; 
+    vih : 5.5 ; 
+    vimin : 0 ; 
+    vimax : 5.5 ; 
+  }
+
+  output_voltage(default) { 
+    vol : 0 ; 
+    voh : 5.5 ; 
+    vomin : 0 ; 
+    vomax : 5.5 ; 
+  }
+
+  lu_table_template(cnst_ctin_rtin_10x10) { 
+    variable_1 : constrained_pin_transition ; 
+    variable_2 : related_pin_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(ndw_ntin_nvolt_10x13) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : normalized_voltage ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13");
+  }
+
+  lu_table_template(tmg_ntin_10) { 
+    variable_1 : input_net_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(tmg_ntin_oload_10x10) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_10) { 
+    variable_1 : input_transition_time ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_oload_10x10) { 
+    variable_1 : input_transition_time ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_fall" ; 
+    index_1("0.02, 0.04471, 0.1314, 0.2971, 0.5551, 0.9172, 1.394, 1.994, 2.727, 3.6");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.005589, 0.01118, 0.01677, 0.02235, 0.02794, 0.03353, 0.03912, 0.04471, 0.0503, 0.05589, 0.06148, 0.06706",\
+           "0, 0.01643, 0.03286, 0.04929, 0.06572, 0.08215, 0.09858, 0.115, 0.1314, 0.1479, 0.1643, 0.1807, 0.1972",\
+           "0, 0.03714, 0.07427, 0.1114, 0.1485, 0.1857, 0.2228, 0.2599, 0.2971, 0.3342, 0.3714, 0.4085, 0.4456",\
+           "0, 0.06939, 0.1388, 0.2082, 0.2776, 0.347, 0.4163, 0.4857, 0.5551, 0.6245, 0.6939, 0.7633, 0.8327",\
+           "0, 0.1147, 0.2293, 0.344, 0.4586, 0.5733, 0.6879, 0.8026, 0.9172, 1.032, 1.147, 1.261, 1.376",\
+           "0, 0.1742, 0.3484, 0.5226, 0.6968, 0.871, 1.045, 1.219, 1.394, 1.568, 1.742, 1.916, 2.09",\
+           "0, 0.2492, 0.4985, 0.7477, 0.9969, 1.246, 1.495, 1.745, 1.994, 2.243, 2.492, 2.742, 2.991",\
+           "0, 0.3408, 0.6817, 1.022, 1.363, 1.704, 2.045, 2.386, 2.727, 3.067, 3.408, 3.749, 4.09",\
+           "0, 0.45, 0.9, 1.35, 1.8, 2.25, 2.7, 3.15, 3.6, 4.05, 4.5, 4.95, 5.4");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_rise" ; 
+    index_1("0.02, 0.04471, 0.1314, 0.2971, 0.5551, 0.9172, 1.394, 1.994, 2.727, 3.6");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.005589, 0.01118, 0.01677, 0.02235, 0.02794, 0.03353, 0.03912, 0.04471, 0.0503, 0.05589, 0.06148, 0.06706",\
+           "0, 0.01643, 0.03286, 0.04929, 0.06572, 0.08215, 0.09858, 0.115, 0.1314, 0.1479, 0.1643, 0.1807, 0.1972",\
+           "0, 0.03714, 0.07427, 0.1114, 0.1485, 0.1857, 0.2228, 0.2599, 0.2971, 0.3342, 0.3714, 0.4085, 0.4456",\
+           "0, 0.06939, 0.1388, 0.2082, 0.2776, 0.347, 0.4163, 0.4857, 0.5551, 0.6245, 0.6939, 0.7633, 0.8327",\
+           "0, 0.1147, 0.2293, 0.344, 0.4586, 0.5733, 0.6879, 0.8026, 0.9172, 1.032, 1.147, 1.261, 1.376",\
+           "0, 0.1742, 0.3484, 0.5226, 0.6968, 0.871, 1.045, 1.219, 1.394, 1.568, 1.742, 1.916, 2.09",\
+           "0, 0.2492, 0.4985, 0.7477, 0.9969, 1.246, 1.495, 1.745, 1.994, 2.243, 2.492, 2.742, 2.991",\
+           "0, 0.3408, 0.6817, 1.022, 1.363, 1.704, 2.045, 2.386, 2.727, 3.067, 3.408, 3.749, 4.09",\
+           "0, 0.45, 0.9, 1.35, 1.8, 2.25, 2.7, 3.15, 3.6, 4.05, 4.5, 4.95, 5.4");
+  }
+}

--- a/liberty/gf180mcu_fd_sc_mcu9t5v0__ff_n40C_1v98.lib
+++ b/liberty/gf180mcu_fd_sc_mcu9t5v0__ff_n40C_1v98.lib
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 GlobalFoundries PDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+library(gf180mcu_fd_sc_mcu9t5v0__ff_n40C_1v98) { 
+  delay_model : table_lookup ; 
+  library_features(report_delay_calculation, report_power_calculation);
+  time_unit : 1ns ; 
+  voltage_unit : 1V ; 
+  current_unit : 1mA ; 
+  capacitive_load_unit(1, pf);
+  pulling_resistance_unit : 1ohm ; 
+  leakage_power_unit : 1uW ; 
+  input_threshold_pct_fall : 50 ; 
+  input_threshold_pct_rise : 50 ; 
+  output_threshold_pct_fall : 50 ; 
+  output_threshold_pct_rise : 50 ; 
+  slew_derate_from_library : 0.5 ; 
+  slew_lower_threshold_pct_fall : 30 ; 
+  slew_lower_threshold_pct_rise : 30 ; 
+  slew_upper_threshold_pct_fall : 70 ; 
+  slew_upper_threshold_pct_rise : 70 ; 
+  nom_process : 1 ; 
+  nom_temperature : -40 ; 
+  nom_voltage : 1.98 ; 
+  voltage_map(VNW, 1.98);
+  voltage_map(VDD, 1.98);
+  voltage_map(VSS, 0);
+  voltage_map(VPW, 0);
+
+  operating_conditions(gf180mcu_fd_sc_mcu9t5v0__ff_n40C_1v98) { 
+    process : 1 ; 
+    temperature : -40 ; 
+    voltage : 1.98 ; 
+  }
+
+  input_voltage(default) { 
+    vil : 0 ; 
+    vih : 1.98 ; 
+    vimin : 0 ; 
+    vimax : 1.98 ; 
+  }
+
+  output_voltage(default) { 
+    vol : 0 ; 
+    voh : 1.98 ; 
+    vomin : 0 ; 
+    vomax : 1.98 ; 
+  }
+
+  lu_table_template(cnst_ctin_rtin_10x10) { 
+    variable_1 : constrained_pin_transition ; 
+    variable_2 : related_pin_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(ndw_ntin_nvolt_10x13) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : normalized_voltage ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13");
+  }
+
+  lu_table_template(tmg_ntin_10) { 
+    variable_1 : input_net_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(tmg_ntin_oload_10x10) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_10) { 
+    variable_1 : input_transition_time ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_oload_10x10) { 
+    variable_1 : input_transition_time ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_fall" ; 
+    index_1("0.02, 0.06127, 0.2062, 0.4828, 0.9139, 1.519, 2.315, 3.317, 4.541, 6");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.007659, 0.01532, 0.02298, 0.03064, 0.0383, 0.04596, 0.05362, 0.06127, 0.06893, 0.07659, 0.08425, 0.09191",\
+           "0, 0.02577, 0.05154, 0.07731, 0.1031, 0.1288, 0.1546, 0.1804, 0.2062, 0.2319, 0.2577, 0.2835, 0.3092",\
+           "0, 0.06035, 0.1207, 0.1811, 0.2414, 0.3018, 0.3621, 0.4225, 0.4828, 0.5432, 0.6035, 0.6639, 0.7243",\
+           "0, 0.1142, 0.2285, 0.3427, 0.4569, 0.5712, 0.6854, 0.7996, 0.9139, 1.028, 1.142, 1.257, 1.371",\
+           "0, 0.1898, 0.3797, 0.5695, 0.7593, 0.9492, 1.139, 1.329, 1.519, 1.709, 1.898, 2.088, 2.278",\
+           "0, 0.2893, 0.5786, 0.868, 1.157, 1.447, 1.736, 2.025, 2.315, 2.604, 2.893, 3.182, 3.472",\
+           "0, 0.4146, 0.8293, 1.244, 1.659, 2.073, 2.488, 2.903, 3.317, 3.732, 4.146, 4.561, 4.976",\
+           "0, 0.5676, 1.135, 1.703, 2.271, 2.838, 3.406, 3.973, 4.541, 5.109, 5.676, 6.244, 6.812",\
+           "0, 0.75, 1.5, 2.25, 3, 3.75, 4.5, 5.25, 6, 6.75, 7.5, 8.25, 9");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_rise" ; 
+    index_1("0.02, 0.06127, 0.2062, 0.4828, 0.9139, 1.519, 2.315, 3.317, 4.541, 6");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.007659, 0.01532, 0.02298, 0.03064, 0.0383, 0.04596, 0.05362, 0.06127, 0.06893, 0.07659, 0.08425, 0.09191",\
+           "0, 0.02577, 0.05154, 0.07731, 0.1031, 0.1288, 0.1546, 0.1804, 0.2062, 0.2319, 0.2577, 0.2835, 0.3092",\
+           "0, 0.06035, 0.1207, 0.1811, 0.2414, 0.3018, 0.3621, 0.4225, 0.4828, 0.5432, 0.6035, 0.6639, 0.7243",\
+           "0, 0.1142, 0.2285, 0.3427, 0.4569, 0.5712, 0.6854, 0.7996, 0.9139, 1.028, 1.142, 1.257, 1.371",\
+           "0, 0.1898, 0.3797, 0.5695, 0.7593, 0.9492, 1.139, 1.329, 1.519, 1.709, 1.898, 2.088, 2.278",\
+           "0, 0.2893, 0.5786, 0.868, 1.157, 1.447, 1.736, 2.025, 2.315, 2.604, 2.893, 3.182, 3.472",\
+           "0, 0.4146, 0.8293, 1.244, 1.659, 2.073, 2.488, 2.903, 3.317, 3.732, 4.146, 4.561, 4.976",\
+           "0, 0.5676, 1.135, 1.703, 2.271, 2.838, 3.406, 3.973, 4.541, 5.109, 5.676, 6.244, 6.812",\
+           "0, 0.75, 1.5, 2.25, 3, 3.75, 4.5, 5.25, 6, 6.75, 7.5, 8.25, 9");
+  }
+}

--- a/liberty/gf180mcu_fd_sc_mcu9t5v0__ff_n40C_3v60.lib
+++ b/liberty/gf180mcu_fd_sc_mcu9t5v0__ff_n40C_3v60.lib
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 GlobalFoundries PDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+library(gf180mcu_fd_sc_mcu9t5v0__ff_n40C_3v60) { 
+  delay_model : table_lookup ; 
+  library_features(report_delay_calculation, report_power_calculation);
+  time_unit : 1ns ; 
+  voltage_unit : 1V ; 
+  current_unit : 1mA ; 
+  capacitive_load_unit(1, pf);
+  pulling_resistance_unit : 1ohm ; 
+  leakage_power_unit : 1uW ; 
+  input_threshold_pct_fall : 50 ; 
+  input_threshold_pct_rise : 50 ; 
+  output_threshold_pct_fall : 50 ; 
+  output_threshold_pct_rise : 50 ; 
+  slew_derate_from_library : 0.5 ; 
+  slew_lower_threshold_pct_fall : 30 ; 
+  slew_lower_threshold_pct_rise : 30 ; 
+  slew_upper_threshold_pct_fall : 70 ; 
+  slew_upper_threshold_pct_rise : 70 ; 
+  nom_process : 1 ; 
+  nom_temperature : -40 ; 
+  nom_voltage : 3.6 ; 
+  voltage_map(VNW, 3.6);
+  voltage_map(VDD, 3.6);
+  voltage_map(VSS, 0);
+  voltage_map(VPW, 0);
+
+  operating_conditions(gf180mcu_fd_sc_mcu9t5v0__ff_n40C_3v60) { 
+    process : 1 ; 
+    temperature : -40 ; 
+    voltage : 3.6 ; 
+  }
+
+  input_voltage(default) { 
+    vil : 0 ; 
+    vih : 3.6 ; 
+    vimin : 0 ; 
+    vimax : 3.6 ; 
+  }
+
+  output_voltage(default) { 
+    vol : 0 ; 
+    voh : 3.6 ; 
+    vomin : 0 ; 
+    vomax : 3.6 ; 
+  }
+
+  lu_table_template(cnst_ctin_rtin_10x10) { 
+    variable_1 : constrained_pin_transition ; 
+    variable_2 : related_pin_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(ndw_ntin_nvolt_10x13) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : normalized_voltage ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13");
+  }
+
+  lu_table_template(tmg_ntin_10) { 
+    variable_1 : input_net_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(tmg_ntin_oload_10x10) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_10) { 
+    variable_1 : input_transition_time ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_oload_10x10) { 
+    variable_1 : input_transition_time ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_fall" ; 
+    index_1("0.02, 0.05023, 0.1564, 0.359, 0.6747, 1.118, 1.701, 2.435, 3.331, 4.4");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.006279, 0.01256, 0.01884, 0.02512, 0.03139, 0.03767, 0.04395, 0.05023, 0.05651, 0.06279, 0.06907, 0.07535",\
+           "0, 0.01954, 0.03909, 0.05863, 0.07818, 0.09772, 0.1173, 0.1368, 0.1564, 0.1759, 0.1954, 0.215, 0.2345",\
+           "0, 0.04487, 0.08975, 0.1346, 0.1795, 0.2244, 0.2692, 0.3141, 0.359, 0.4039, 0.4487, 0.4936, 0.5385",\
+           "0, 0.08434, 0.1687, 0.253, 0.3374, 0.4217, 0.506, 0.5904, 0.6747, 0.7591, 0.8434, 0.9277, 1.012",\
+           "0, 0.1397, 0.2794, 0.4191, 0.5589, 0.6986, 0.8383, 0.978, 1.118, 1.257, 1.397, 1.537, 1.677",\
+           "0, 0.2126, 0.4252, 0.6377, 0.8503, 1.063, 1.275, 1.488, 1.701, 1.913, 2.126, 2.338, 2.551",\
+           "0, 0.3044, 0.6087, 0.9131, 1.217, 1.522, 1.826, 2.131, 2.435, 2.739, 3.044, 3.348, 3.652",\
+           "0, 0.4164, 0.8329, 1.249, 1.666, 2.082, 2.499, 2.915, 3.331, 3.748, 4.164, 4.581, 4.997",\
+           "0, 0.55, 1.1, 1.65, 2.2, 2.75, 3.3, 3.85, 4.4, 4.95, 5.5, 6.05, 6.6");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_rise" ; 
+    index_1("0.02, 0.05023, 0.1564, 0.359, 0.6747, 1.118, 1.701, 2.435, 3.331, 4.4");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.006279, 0.01256, 0.01884, 0.02512, 0.03139, 0.03767, 0.04395, 0.05023, 0.05651, 0.06279, 0.06907, 0.07535",\
+           "0, 0.01954, 0.03909, 0.05863, 0.07818, 0.09772, 0.1173, 0.1368, 0.1564, 0.1759, 0.1954, 0.215, 0.2345",\
+           "0, 0.04487, 0.08975, 0.1346, 0.1795, 0.2244, 0.2692, 0.3141, 0.359, 0.4039, 0.4487, 0.4936, 0.5385",\
+           "0, 0.08434, 0.1687, 0.253, 0.3374, 0.4217, 0.506, 0.5904, 0.6747, 0.7591, 0.8434, 0.9277, 1.012",\
+           "0, 0.1397, 0.2794, 0.4191, 0.5589, 0.6986, 0.8383, 0.978, 1.118, 1.257, 1.397, 1.537, 1.677",\
+           "0, 0.2126, 0.4252, 0.6377, 0.8503, 1.063, 1.275, 1.488, 1.701, 1.913, 2.126, 2.338, 2.551",\
+           "0, 0.3044, 0.6087, 0.9131, 1.217, 1.522, 1.826, 2.131, 2.435, 2.739, 3.044, 3.348, 3.652",\
+           "0, 0.4164, 0.8329, 1.249, 1.666, 2.082, 2.499, 2.915, 3.331, 3.748, 4.164, 4.581, 4.997",\
+           "0, 0.55, 1.1, 1.65, 2.2, 2.75, 3.3, 3.85, 4.4, 4.95, 5.5, 6.05, 6.6");
+  }
+}

--- a/liberty/gf180mcu_fd_sc_mcu9t5v0__ff_n40C_5v50.lib
+++ b/liberty/gf180mcu_fd_sc_mcu9t5v0__ff_n40C_5v50.lib
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 GlobalFoundries PDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+library(gf180mcu_fd_sc_mcu9t5v0__ff_n40C_5v50) { 
+  delay_model : table_lookup ; 
+  library_features(report_delay_calculation, report_power_calculation);
+  time_unit : 1ns ; 
+  voltage_unit : 1V ; 
+  current_unit : 1mA ; 
+  capacitive_load_unit(1, pf);
+  pulling_resistance_unit : 1ohm ; 
+  leakage_power_unit : 1uW ; 
+  input_threshold_pct_fall : 50 ; 
+  input_threshold_pct_rise : 50 ; 
+  output_threshold_pct_fall : 50 ; 
+  output_threshold_pct_rise : 50 ; 
+  slew_derate_from_library : 0.5 ; 
+  slew_lower_threshold_pct_fall : 30 ; 
+  slew_lower_threshold_pct_rise : 30 ; 
+  slew_upper_threshold_pct_fall : 70 ; 
+  slew_upper_threshold_pct_rise : 70 ; 
+  nom_process : 1 ; 
+  nom_temperature : -40 ; 
+  nom_voltage : 5.5 ; 
+  voltage_map(VNW, 5.5);
+  voltage_map(VDD, 5.5);
+  voltage_map(VSS, 0);
+  voltage_map(VPW, 0);
+
+  operating_conditions(gf180mcu_fd_sc_mcu9t5v0__ff_n40C_5v50) { 
+    process : 1 ; 
+    temperature : -40 ; 
+    voltage : 5.5 ; 
+  }
+
+  input_voltage(default) { 
+    vil : 0 ; 
+    vih : 5.5 ; 
+    vimin : 0 ; 
+    vimax : 5.5 ; 
+  }
+
+  output_voltage(default) { 
+    vol : 0 ; 
+    voh : 5.5 ; 
+    vomin : 0 ; 
+    vomax : 5.5 ; 
+  }
+
+  lu_table_template(cnst_ctin_rtin_10x10) { 
+    variable_1 : constrained_pin_transition ; 
+    variable_2 : related_pin_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(ndw_ntin_nvolt_10x13) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : normalized_voltage ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13");
+  }
+
+  lu_table_template(tmg_ntin_10) { 
+    variable_1 : input_net_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(tmg_ntin_oload_10x10) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_10) { 
+    variable_1 : input_transition_time ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_oload_10x10) { 
+    variable_1 : input_transition_time ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_fall" ; 
+    index_1("0.02, 0.03919, 0.1065, 0.2352, 0.4356, 0.7167, 1.087, 1.553, 2.122, 2.8");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.004898, 0.009797, 0.0147, 0.01959, 0.02449, 0.02939, 0.03429, 0.03919, 0.04409, 0.04898, 0.05388, 0.05878",\
+           "0, 0.01332, 0.02664, 0.03995, 0.05327, 0.06659, 0.07991, 0.09322, 0.1065, 0.1199, 0.1332, 0.1465, 0.1598",\
+           "0, 0.0294, 0.05879, 0.08819, 0.1176, 0.147, 0.1764, 0.2058, 0.2352, 0.2646, 0.294, 0.3234, 0.3527",\
+           "0, 0.05444, 0.1089, 0.1633, 0.2178, 0.2722, 0.3267, 0.3811, 0.4356, 0.49, 0.5444, 0.5989, 0.6533",\
+           "0, 0.08959, 0.1792, 0.2688, 0.3584, 0.4479, 0.5375, 0.6271, 0.7167, 0.8063, 0.8959, 0.9855, 1.075",\
+           "0, 0.1358, 0.2717, 0.4075, 0.5433, 0.6792, 0.815, 0.9509, 1.087, 1.223, 1.358, 1.494, 1.63",\
+           "0, 0.1941, 0.3882, 0.5823, 0.7764, 0.9705, 1.165, 1.359, 1.553, 1.747, 1.941, 2.135, 2.329",\
+           "0, 0.2652, 0.5304, 0.7957, 1.061, 1.326, 1.591, 1.857, 2.122, 2.387, 2.652, 2.917, 3.183",\
+           "0, 0.35, 0.7, 1.05, 1.4, 1.75, 2.1, 2.45, 2.8, 3.15, 3.5, 3.85, 4.2");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_rise" ; 
+    index_1("0.02, 0.03919, 0.1065, 0.2352, 0.4356, 0.7167, 1.087, 1.553, 2.122, 2.8");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.004898, 0.009797, 0.0147, 0.01959, 0.02449, 0.02939, 0.03429, 0.03919, 0.04409, 0.04898, 0.05388, 0.05878",\
+           "0, 0.01332, 0.02664, 0.03995, 0.05327, 0.06659, 0.07991, 0.09322, 0.1065, 0.1199, 0.1332, 0.1465, 0.1598",\
+           "0, 0.0294, 0.05879, 0.08819, 0.1176, 0.147, 0.1764, 0.2058, 0.2352, 0.2646, 0.294, 0.3234, 0.3527",\
+           "0, 0.05444, 0.1089, 0.1633, 0.2178, 0.2722, 0.3267, 0.3811, 0.4356, 0.49, 0.5444, 0.5989, 0.6533",\
+           "0, 0.08959, 0.1792, 0.2688, 0.3584, 0.4479, 0.5375, 0.6271, 0.7167, 0.8063, 0.8959, 0.9855, 1.075",\
+           "0, 0.1358, 0.2717, 0.4075, 0.5433, 0.6792, 0.815, 0.9509, 1.087, 1.223, 1.358, 1.494, 1.63",\
+           "0, 0.1941, 0.3882, 0.5823, 0.7764, 0.9705, 1.165, 1.359, 1.553, 1.747, 1.941, 2.135, 2.329",\
+           "0, 0.2652, 0.5304, 0.7957, 1.061, 1.326, 1.591, 1.857, 2.122, 2.387, 2.652, 2.917, 3.183",\
+           "0, 0.35, 0.7, 1.05, 1.4, 1.75, 2.1, 2.45, 2.8, 3.15, 3.5, 3.85, 4.2");
+  }
+}

--- a/liberty/gf180mcu_fd_sc_mcu9t5v0__ss_125C_1v62.lib
+++ b/liberty/gf180mcu_fd_sc_mcu9t5v0__ss_125C_1v62.lib
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 GlobalFoundries PDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+library(gf180mcu_fd_sc_mcu9t5v0__ss_125C_1v62) { 
+  delay_model : table_lookup ; 
+  library_features(report_delay_calculation, report_power_calculation);
+  time_unit : 1ns ; 
+  voltage_unit : 1V ; 
+  current_unit : 1mA ; 
+  capacitive_load_unit(1, pf);
+  pulling_resistance_unit : 1ohm ; 
+  leakage_power_unit : 1uW ; 
+  input_threshold_pct_fall : 50 ; 
+  input_threshold_pct_rise : 50 ; 
+  output_threshold_pct_fall : 50 ; 
+  output_threshold_pct_rise : 50 ; 
+  slew_derate_from_library : 0.5 ; 
+  slew_lower_threshold_pct_fall : 30 ; 
+  slew_lower_threshold_pct_rise : 30 ; 
+  slew_upper_threshold_pct_fall : 70 ; 
+  slew_upper_threshold_pct_rise : 70 ; 
+  nom_process : 1 ; 
+  nom_temperature : 125 ; 
+  nom_voltage : 1.62 ; 
+  voltage_map(VNW, 1.62);
+  voltage_map(VDD, 1.62);
+  voltage_map(VSS, 0);
+  voltage_map(VPW, 0);
+
+  operating_conditions(gf180mcu_fd_sc_mcu9t5v0__ss_125C_1v62) { 
+    process : 1 ; 
+    temperature : 125 ; 
+    voltage : 1.62 ; 
+  }
+
+  input_voltage(default) { 
+    vil : 0 ; 
+    vih : 1.62 ; 
+    vimin : 0 ; 
+    vimax : 1.62 ; 
+  }
+
+  output_voltage(default) { 
+    vol : 0 ; 
+    voh : 1.62 ; 
+    vomin : 0 ; 
+    vomax : 1.62 ; 
+  }
+
+  lu_table_template(cnst_ctin_rtin_10x10) { 
+    variable_1 : constrained_pin_transition ; 
+    variable_2 : related_pin_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(ndw_ntin_nvolt_10x13) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : normalized_voltage ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13");
+  }
+
+  lu_table_template(tmg_ntin_10) { 
+    variable_1 : input_net_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(tmg_ntin_oload_10x10) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_10) { 
+    variable_1 : input_transition_time ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_oload_10x10) { 
+    variable_1 : input_transition_time ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_fall" ; 
+    index_1("0.02, 0.1579, 0.642, 1.566, 3.007, 5.027, 7.686, 11.04, 15.13, 20");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.01974, 0.03948, 0.05921, 0.07895, 0.09869, 0.1184, 0.1382, 0.1579, 0.1776, 0.1974, 0.2171, 0.2369",\
+           "0, 0.08025, 0.1605, 0.2407, 0.321, 0.4012, 0.4815, 0.5617, 0.642, 0.7222, 0.8025, 0.8827, 0.963",\
+           "0, 0.1958, 0.3916, 0.5874, 0.7832, 0.979, 1.175, 1.371, 1.566, 1.762, 1.958, 2.154, 2.35",\
+           "0, 0.3758, 0.7516, 1.127, 1.503, 1.879, 2.255, 2.631, 3.007, 3.382, 3.758, 4.134, 4.51",\
+           "0, 0.6284, 1.257, 1.885, 2.514, 3.142, 3.77, 4.399, 5.027, 5.656, 6.284, 6.913, 7.541",\
+           "0, 0.9608, 1.922, 2.882, 3.843, 4.804, 5.765, 6.726, 7.686, 8.647, 9.608, 10.57, 11.53",\
+           "0, 1.38, 2.759, 4.139, 5.518, 6.898, 8.277, 9.657, 11.04, 12.42, 13.8, 15.17, 16.55",\
+           "0, 1.891, 3.781, 5.672, 7.563, 9.454, 11.34, 13.23, 15.13, 17.02, 18.91, 20.8, 22.69",\
+           "0, 2.5, 5, 7.5, 10, 12.5, 15, 17.5, 20, 22.5, 25, 27.5, 30");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_rise" ; 
+    index_1("0.02, 0.1579, 0.642, 1.566, 3.007, 5.027, 7.686, 11.04, 15.13, 20");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.01974, 0.03948, 0.05921, 0.07895, 0.09869, 0.1184, 0.1382, 0.1579, 0.1776, 0.1974, 0.2171, 0.2369",\
+           "0, 0.08025, 0.1605, 0.2407, 0.321, 0.4012, 0.4815, 0.5617, 0.642, 0.7222, 0.8025, 0.8827, 0.963",\
+           "0, 0.1958, 0.3916, 0.5874, 0.7832, 0.979, 1.175, 1.371, 1.566, 1.762, 1.958, 2.154, 2.35",\
+           "0, 0.3758, 0.7516, 1.127, 1.503, 1.879, 2.255, 2.631, 3.007, 3.382, 3.758, 4.134, 4.51",\
+           "0, 0.6284, 1.257, 1.885, 2.514, 3.142, 3.77, 4.399, 5.027, 5.656, 6.284, 6.913, 7.541",\
+           "0, 0.9608, 1.922, 2.882, 3.843, 4.804, 5.765, 6.726, 7.686, 8.647, 9.608, 10.57, 11.53",\
+           "0, 1.38, 2.759, 4.139, 5.518, 6.898, 8.277, 9.657, 11.04, 12.42, 13.8, 15.17, 16.55",\
+           "0, 1.891, 3.781, 5.672, 7.563, 9.454, 11.34, 13.23, 15.13, 17.02, 18.91, 20.8, 22.69",\
+           "0, 2.5, 5, 7.5, 10, 12.5, 15, 17.5, 20, 22.5, 25, 27.5, 30");
+  }
+}

--- a/liberty/gf180mcu_fd_sc_mcu9t5v0__ss_125C_3v00.lib
+++ b/liberty/gf180mcu_fd_sc_mcu9t5v0__ss_125C_3v00.lib
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 GlobalFoundries PDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+library(gf180mcu_fd_sc_mcu9t5v0__ss_125C_3v00) { 
+  delay_model : table_lookup ; 
+  library_features(report_delay_calculation, report_power_calculation);
+  time_unit : 1ns ; 
+  voltage_unit : 1V ; 
+  current_unit : 1mA ; 
+  capacitive_load_unit(1, pf);
+  pulling_resistance_unit : 1ohm ; 
+  leakage_power_unit : 1uW ; 
+  input_threshold_pct_fall : 50 ; 
+  input_threshold_pct_rise : 50 ; 
+  output_threshold_pct_fall : 50 ; 
+  output_threshold_pct_rise : 50 ; 
+  slew_derate_from_library : 0.5 ; 
+  slew_lower_threshold_pct_fall : 30 ; 
+  slew_lower_threshold_pct_rise : 30 ; 
+  slew_upper_threshold_pct_fall : 70 ; 
+  slew_upper_threshold_pct_rise : 70 ; 
+  nom_process : 1 ; 
+  nom_temperature : 125 ; 
+  nom_voltage : 3 ; 
+  voltage_map(VNW, 3);
+  voltage_map(VDD, 3);
+  voltage_map(VSS, 0);
+  voltage_map(VPW, 0);
+
+  operating_conditions(gf180mcu_fd_sc_mcu9t5v0__ss_125C_3v00) { 
+    process : 1 ; 
+    temperature : 125 ; 
+    voltage : 3 ; 
+  }
+
+  input_voltage(default) { 
+    vil : 0 ; 
+    vih : 3 ; 
+    vimin : 0 ; 
+    vimax : 3 ; 
+  }
+
+  output_voltage(default) { 
+    vol : 0 ; 
+    voh : 3 ; 
+    vomin : 0 ; 
+    vomax : 3 ; 
+  }
+
+  lu_table_template(cnst_ctin_rtin_10x10) { 
+    variable_1 : constrained_pin_transition ; 
+    variable_2 : related_pin_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(ndw_ntin_nvolt_10x13) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : normalized_voltage ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13");
+  }
+
+  lu_table_template(tmg_ntin_10) { 
+    variable_1 : input_net_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(tmg_ntin_oload_10x10) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_10) { 
+    variable_1 : input_transition_time ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_oload_10x10) { 
+    variable_1 : input_transition_time ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_fall" ; 
+    index_1("0.02, 0.111, 0.4303, 1.04, 1.99, 3.323, 5.077, 7.287, 9.985, 13.2");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.01387, 0.02774, 0.04161, 0.05549, 0.06936, 0.08323, 0.0971, 0.111, 0.1248, 0.1387, 0.1526, 0.1665",\
+           "0, 0.05379, 0.1076, 0.1614, 0.2151, 0.2689, 0.3227, 0.3765, 0.4303, 0.4841, 0.5379, 0.5917, 0.6454",\
+           "0, 0.13, 0.26, 0.39, 0.52, 0.6501, 0.7801, 0.9101, 1.04, 1.17, 1.3, 1.43, 1.56",\
+           "0, 0.2488, 0.4975, 0.7463, 0.9951, 1.244, 1.493, 1.741, 1.99, 2.239, 2.488, 2.736, 2.985",\
+           "0, 0.4154, 0.8308, 1.246, 1.662, 2.077, 2.492, 2.908, 3.323, 3.739, 4.154, 4.569, 4.985",\
+           "0, 0.6346, 1.269, 1.904, 2.539, 3.173, 3.808, 4.443, 5.077, 5.712, 6.346, 6.981, 7.616",\
+           "0, 0.9109, 1.822, 2.733, 3.643, 4.554, 5.465, 6.376, 7.287, 8.198, 9.109, 10.02, 10.93",\
+           "0, 1.248, 2.496, 3.744, 4.992, 6.24, 7.488, 8.737, 9.985, 11.23, 12.48, 13.73, 14.98",\
+           "0, 1.65, 3.3, 4.95, 6.6, 8.25, 9.9, 11.55, 13.2, 14.85, 16.5, 18.15, 19.8");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_rise" ; 
+    index_1("0.02, 0.111, 0.4303, 1.04, 1.99, 3.323, 5.077, 7.287, 9.985, 13.2");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.01387, 0.02774, 0.04161, 0.05549, 0.06936, 0.08323, 0.0971, 0.111, 0.1248, 0.1387, 0.1526, 0.1665",\
+           "0, 0.05379, 0.1076, 0.1614, 0.2151, 0.2689, 0.3227, 0.3765, 0.4303, 0.4841, 0.5379, 0.5917, 0.6454",\
+           "0, 0.13, 0.26, 0.39, 0.52, 0.6501, 0.7801, 0.9101, 1.04, 1.17, 1.3, 1.43, 1.56",\
+           "0, 0.2488, 0.4975, 0.7463, 0.9951, 1.244, 1.493, 1.741, 1.99, 2.239, 2.488, 2.736, 2.985",\
+           "0, 0.4154, 0.8308, 1.246, 1.662, 2.077, 2.492, 2.908, 3.323, 3.739, 4.154, 4.569, 4.985",\
+           "0, 0.6346, 1.269, 1.904, 2.539, 3.173, 3.808, 4.443, 5.077, 5.712, 6.346, 6.981, 7.616",\
+           "0, 0.9109, 1.822, 2.733, 3.643, 4.554, 5.465, 6.376, 7.287, 8.198, 9.109, 10.02, 10.93",\
+           "0, 1.248, 2.496, 3.744, 4.992, 6.24, 7.488, 8.737, 9.985, 11.23, 12.48, 13.73, 14.98",\
+           "0, 1.65, 3.3, 4.95, 6.6, 8.25, 9.9, 11.55, 13.2, 14.85, 16.5, 18.15, 19.8");
+  }
+}

--- a/liberty/gf180mcu_fd_sc_mcu9t5v0__ss_125C_4v50.lib
+++ b/liberty/gf180mcu_fd_sc_mcu9t5v0__ss_125C_4v50.lib
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 GlobalFoundries PDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+library(gf180mcu_fd_sc_mcu9t5v0__ss_125C_4v50) { 
+  delay_model : table_lookup ; 
+  library_features(report_delay_calculation, report_power_calculation);
+  time_unit : 1ns ; 
+  voltage_unit : 1V ; 
+  current_unit : 1mA ; 
+  capacitive_load_unit(1, pf);
+  pulling_resistance_unit : 1ohm ; 
+  leakage_power_unit : 1uW ; 
+  input_threshold_pct_fall : 50 ; 
+  input_threshold_pct_rise : 50 ; 
+  output_threshold_pct_fall : 50 ; 
+  output_threshold_pct_rise : 50 ; 
+  slew_derate_from_library : 0.5 ; 
+  slew_lower_threshold_pct_fall : 30 ; 
+  slew_lower_threshold_pct_rise : 30 ; 
+  slew_upper_threshold_pct_fall : 70 ; 
+  slew_upper_threshold_pct_rise : 70 ; 
+  nom_process : 1 ; 
+  nom_temperature : 125 ; 
+  nom_voltage : 4.5 ; 
+  voltage_map(VNW, 4.5);
+  voltage_map(VDD, 4.5);
+  voltage_map(VSS, 0);
+  voltage_map(VPW, 0);
+
+  operating_conditions(gf180mcu_fd_sc_mcu9t5v0__ss_125C_4v50) { 
+    process : 1 ; 
+    temperature : 125 ; 
+    voltage : 4.5 ; 
+  }
+
+  input_voltage(default) { 
+    vil : 0 ; 
+    vih : 4.5 ; 
+    vimin : 0 ; 
+    vimax : 4.5 ; 
+  }
+
+  output_voltage(default) { 
+    vol : 0 ; 
+    voh : 4.5 ; 
+    vomin : 0 ; 
+    vomax : 4.5 ; 
+  }
+
+  lu_table_template(cnst_ctin_rtin_10x10) { 
+    variable_1 : constrained_pin_transition ; 
+    variable_2 : related_pin_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(ndw_ntin_nvolt_10x13) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : normalized_voltage ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13");
+  }
+
+  lu_table_template(tmg_ntin_10) { 
+    variable_1 : input_net_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(tmg_ntin_oload_10x10) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_10) { 
+    variable_1 : input_transition_time ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_oload_10x10) { 
+    variable_1 : input_transition_time ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_fall" ; 
+    index_1("0.02, 0.06956, 0.2435, 0.5757, 1.093, 1.819, 2.775, 3.979, 5.448, 7.2");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.008695, 0.01739, 0.02608, 0.03478, 0.04347, 0.05217, 0.06086, 0.06956, 0.07825, 0.08695, 0.09564, 0.1043",\
+           "0, 0.03044, 0.06088, 0.09132, 0.1218, 0.1522, 0.1826, 0.2131, 0.2435, 0.274, 0.3044, 0.3348, 0.3653",\
+           "0, 0.07196, 0.1439, 0.2159, 0.2879, 0.3598, 0.4318, 0.5037, 0.5757, 0.6477, 0.7196, 0.7916, 0.8636",\
+           "0, 0.1367, 0.2733, 0.41, 0.5466, 0.6833, 0.8199, 0.9566, 1.093, 1.23, 1.367, 1.503, 1.64",\
+           "0, 0.2274, 0.4549, 0.6823, 0.9097, 1.137, 1.365, 1.592, 1.819, 2.047, 2.274, 2.502, 2.729",\
+           "0, 0.3469, 0.6937, 1.041, 1.387, 1.734, 2.081, 2.428, 2.775, 3.122, 3.469, 3.816, 4.162",\
+           "0, 0.4973, 0.9947, 1.492, 1.989, 2.487, 2.984, 3.481, 3.979, 4.476, 4.973, 5.471, 5.968",\
+           "0, 0.681, 1.362, 2.043, 2.724, 3.405, 4.086, 4.767, 5.448, 6.129, 6.81, 7.491, 8.173",\
+           "0, 0.9, 1.8, 2.7, 3.6, 4.5, 5.4, 6.3, 7.2, 8.1, 9, 9.9, 10.8");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_rise" ; 
+    index_1("0.02, 0.06956, 0.2435, 0.5757, 1.093, 1.819, 2.775, 3.979, 5.448, 7.2");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.008695, 0.01739, 0.02608, 0.03478, 0.04347, 0.05217, 0.06086, 0.06956, 0.07825, 0.08695, 0.09564, 0.1043",\
+           "0, 0.03044, 0.06088, 0.09132, 0.1218, 0.1522, 0.1826, 0.2131, 0.2435, 0.274, 0.3044, 0.3348, 0.3653",\
+           "0, 0.07196, 0.1439, 0.2159, 0.2879, 0.3598, 0.4318, 0.5037, 0.5757, 0.6477, 0.7196, 0.7916, 0.8636",\
+           "0, 0.1367, 0.2733, 0.41, 0.5466, 0.6833, 0.8199, 0.9566, 1.093, 1.23, 1.367, 1.503, 1.64",\
+           "0, 0.2274, 0.4549, 0.6823, 0.9097, 1.137, 1.365, 1.592, 1.819, 2.047, 2.274, 2.502, 2.729",\
+           "0, 0.3469, 0.6937, 1.041, 1.387, 1.734, 2.081, 2.428, 2.775, 3.122, 3.469, 3.816, 4.162",\
+           "0, 0.4973, 0.9947, 1.492, 1.989, 2.487, 2.984, 3.481, 3.979, 4.476, 4.973, 5.471, 5.968",\
+           "0, 0.681, 1.362, 2.043, 2.724, 3.405, 4.086, 4.767, 5.448, 6.129, 6.81, 7.491, 8.173",\
+           "0, 0.9, 1.8, 2.7, 3.6, 4.5, 5.4, 6.3, 7.2, 8.1, 9, 9.9, 10.8");
+  }
+}

--- a/liberty/gf180mcu_fd_sc_mcu9t5v0__ss_n40C_1v62.lib
+++ b/liberty/gf180mcu_fd_sc_mcu9t5v0__ss_n40C_1v62.lib
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 GlobalFoundries PDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+library(gf180mcu_fd_sc_mcu9t5v0__ss_n40C_1v62) { 
+  delay_model : table_lookup ; 
+  library_features(report_delay_calculation, report_power_calculation);
+  time_unit : 1ns ; 
+  voltage_unit : 1V ; 
+  current_unit : 1mA ; 
+  capacitive_load_unit(1, pf);
+  pulling_resistance_unit : 1ohm ; 
+  leakage_power_unit : 1uW ; 
+  input_threshold_pct_fall : 50 ; 
+  input_threshold_pct_rise : 50 ; 
+  output_threshold_pct_fall : 50 ; 
+  output_threshold_pct_rise : 50 ; 
+  slew_derate_from_library : 0.5 ; 
+  slew_lower_threshold_pct_fall : 30 ; 
+  slew_lower_threshold_pct_rise : 30 ; 
+  slew_upper_threshold_pct_fall : 70 ; 
+  slew_upper_threshold_pct_rise : 70 ; 
+  nom_process : 1 ; 
+  nom_temperature : -40 ; 
+  nom_voltage : 1.62 ; 
+  voltage_map(VNW, 1.62);
+  voltage_map(VDD, 1.62);
+  voltage_map(VSS, 0);
+  voltage_map(VPW, 0);
+
+  operating_conditions(gf180mcu_fd_sc_mcu9t5v0__ss_n40C_1v62) { 
+    process : 1 ; 
+    temperature : -40 ; 
+    voltage : 1.62 ; 
+  }
+
+  input_voltage(default) { 
+    vil : 0 ; 
+    vih : 1.62 ; 
+    vimin : 0 ; 
+    vimax : 1.62 ; 
+  }
+
+  output_voltage(default) { 
+    vol : 0 ; 
+    voh : 1.62 ; 
+    vomin : 0 ; 
+    vomax : 1.62 ; 
+  }
+
+  lu_table_template(cnst_ctin_rtin_10x10) { 
+    variable_1 : constrained_pin_transition ; 
+    variable_2 : related_pin_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(ndw_ntin_nvolt_10x13) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : normalized_voltage ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13");
+  }
+
+  lu_table_template(tmg_ntin_10) { 
+    variable_1 : input_net_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(tmg_ntin_oload_10x10) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_10) { 
+    variable_1 : input_transition_time ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_oload_10x10) { 
+    variable_1 : input_transition_time ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_fall" ; 
+    index_1("0.02, 0.1372, 0.5486, 1.334, 2.558, 4.275, 6.535, 9.382, 12.86, 17");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.01715, 0.0343, 0.05145, 0.0686, 0.08575, 0.1029, 0.12, 0.1372, 0.1543, 0.1715, 0.1886, 0.2058",\
+           "0, 0.06857, 0.1371, 0.2057, 0.2743, 0.3429, 0.4114, 0.48, 0.5486, 0.6172, 0.6857, 0.7543, 0.8229",\
+           "0, 0.1668, 0.3336, 0.5003, 0.6671, 0.8339, 1.001, 1.167, 1.334, 1.501, 1.668, 1.835, 2.001",\
+           "0, 0.3198, 0.6395, 0.9593, 1.279, 1.599, 1.919, 2.238, 2.558, 2.878, 3.198, 3.517, 3.837",\
+           "0, 0.5344, 1.069, 1.603, 2.138, 2.672, 3.207, 3.741, 4.275, 4.81, 5.344, 5.879, 6.413",\
+           "0, 0.8169, 1.634, 2.451, 3.268, 4.085, 4.901, 5.718, 6.535, 7.352, 8.169, 8.986, 9.803",\
+           "0, 1.173, 2.346, 3.518, 4.691, 5.864, 7.037, 8.209, 9.382, 10.55, 11.73, 12.9, 14.07",\
+           "0, 1.607, 3.214, 4.822, 6.429, 8.036, 9.643, 11.25, 12.86, 14.46, 16.07, 17.68, 19.29",\
+           "0, 2.125, 4.25, 6.375, 8.5, 10.62, 12.75, 14.88, 17, 19.12, 21.25, 23.38, 25.5");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_rise" ; 
+    index_1("0.02, 0.1372, 0.5486, 1.334, 2.558, 4.275, 6.535, 9.382, 12.86, 17");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.01715, 0.0343, 0.05145, 0.0686, 0.08575, 0.1029, 0.12, 0.1372, 0.1543, 0.1715, 0.1886, 0.2058",\
+           "0, 0.06857, 0.1371, 0.2057, 0.2743, 0.3429, 0.4114, 0.48, 0.5486, 0.6172, 0.6857, 0.7543, 0.8229",\
+           "0, 0.1668, 0.3336, 0.5003, 0.6671, 0.8339, 1.001, 1.167, 1.334, 1.501, 1.668, 1.835, 2.001",\
+           "0, 0.3198, 0.6395, 0.9593, 1.279, 1.599, 1.919, 2.238, 2.558, 2.878, 3.198, 3.517, 3.837",\
+           "0, 0.5344, 1.069, 1.603, 2.138, 2.672, 3.207, 3.741, 4.275, 4.81, 5.344, 5.879, 6.413",\
+           "0, 0.8169, 1.634, 2.451, 3.268, 4.085, 4.901, 5.718, 6.535, 7.352, 8.169, 8.986, 9.803",\
+           "0, 1.173, 2.346, 3.518, 4.691, 5.864, 7.037, 8.209, 9.382, 10.55, 11.73, 12.9, 14.07",\
+           "0, 1.607, 3.214, 4.822, 6.429, 8.036, 9.643, 11.25, 12.86, 14.46, 16.07, 17.68, 19.29",\
+           "0, 2.125, 4.25, 6.375, 8.5, 10.62, 12.75, 14.88, 17, 19.12, 21.25, 23.38, 25.5");
+  }
+}

--- a/liberty/gf180mcu_fd_sc_mcu9t5v0__ss_n40C_3v00.lib
+++ b/liberty/gf180mcu_fd_sc_mcu9t5v0__ss_n40C_3v00.lib
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 GlobalFoundries PDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+library(gf180mcu_fd_sc_mcu9t5v0__ss_n40C_3v00) { 
+  delay_model : table_lookup ; 
+  library_features(report_delay_calculation, report_power_calculation);
+  time_unit : 1ns ; 
+  voltage_unit : 1V ; 
+  current_unit : 1mA ; 
+  capacitive_load_unit(1, pf);
+  pulling_resistance_unit : 1ohm ; 
+  leakage_power_unit : 1uW ; 
+  input_threshold_pct_fall : 50 ; 
+  input_threshold_pct_rise : 50 ; 
+  output_threshold_pct_fall : 50 ; 
+  output_threshold_pct_rise : 50 ; 
+  slew_derate_from_library : 0.5 ; 
+  slew_lower_threshold_pct_fall : 30 ; 
+  slew_lower_threshold_pct_rise : 30 ; 
+  slew_upper_threshold_pct_fall : 70 ; 
+  slew_upper_threshold_pct_rise : 70 ; 
+  nom_process : 1 ; 
+  nom_temperature : -40 ; 
+  nom_voltage : 3 ; 
+  voltage_map(VNW, 3);
+  voltage_map(VDD, 3);
+  voltage_map(VSS, 0);
+  voltage_map(VPW, 0);
+
+  operating_conditions(gf180mcu_fd_sc_mcu9t5v0__ss_n40C_3v00) { 
+    process : 1 ; 
+    temperature : -40 ; 
+    voltage : 3 ; 
+  }
+
+  input_voltage(default) { 
+    vil : 0 ; 
+    vih : 3 ; 
+    vimin : 0 ; 
+    vimax : 3 ; 
+  }
+
+  output_voltage(default) { 
+    vol : 0 ; 
+    voh : 3 ; 
+    vomin : 0 ; 
+    vomax : 3 ; 
+  }
+
+  lu_table_template(cnst_ctin_rtin_10x10) { 
+    variable_1 : constrained_pin_transition ; 
+    variable_2 : related_pin_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(ndw_ntin_nvolt_10x13) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : normalized_voltage ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13");
+  }
+
+  lu_table_template(tmg_ntin_10) { 
+    variable_1 : input_net_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(tmg_ntin_oload_10x10) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_10) { 
+    variable_1 : input_transition_time ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_oload_10x10) { 
+    variable_1 : input_transition_time ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_fall" ; 
+    index_1("0.02, 0.09717, 0.368, 0.8853, 1.691, 2.822, 4.31, 6.184, 8.473, 11.2");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.01215, 0.02429, 0.03644, 0.04858, 0.06073, 0.07287, 0.08502, 0.09717, 0.1093, 0.1215, 0.1336, 0.1457",\
+           "0, 0.046, 0.09201, 0.138, 0.184, 0.23, 0.276, 0.322, 0.368, 0.414, 0.46, 0.506, 0.5521",\
+           "0, 0.1107, 0.2213, 0.332, 0.4426, 0.5533, 0.664, 0.7746, 0.8853, 0.996, 1.107, 1.217, 1.328",\
+           "0, 0.2114, 0.4228, 0.6342, 0.8456, 1.057, 1.268, 1.48, 1.691, 1.903, 2.114, 2.325, 2.537",\
+           "0, 0.3527, 0.7055, 1.058, 1.411, 1.764, 2.116, 2.469, 2.822, 3.175, 3.527, 3.88, 4.233",\
+           "0, 0.5387, 1.077, 1.616, 2.155, 2.694, 3.232, 3.771, 4.31, 4.849, 5.387, 5.926, 6.465",\
+           "0, 0.773, 1.546, 2.319, 3.092, 3.865, 4.638, 5.411, 6.184, 6.957, 7.73, 8.503, 9.276",\
+           "0, 1.059, 2.118, 3.177, 4.236, 5.295, 6.354, 7.413, 8.473, 9.532, 10.59, 11.65, 12.71",\
+           "0, 1.4, 2.8, 4.2, 5.6, 7, 8.4, 9.8, 11.2, 12.6, 14, 15.4, 16.8");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_rise" ; 
+    index_1("0.02, 0.09717, 0.368, 0.8853, 1.691, 2.822, 4.31, 6.184, 8.473, 11.2");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.01215, 0.02429, 0.03644, 0.04858, 0.06073, 0.07287, 0.08502, 0.09717, 0.1093, 0.1215, 0.1336, 0.1457",\
+           "0, 0.046, 0.09201, 0.138, 0.184, 0.23, 0.276, 0.322, 0.368, 0.414, 0.46, 0.506, 0.5521",\
+           "0, 0.1107, 0.2213, 0.332, 0.4426, 0.5533, 0.664, 0.7746, 0.8853, 0.996, 1.107, 1.217, 1.328",\
+           "0, 0.2114, 0.4228, 0.6342, 0.8456, 1.057, 1.268, 1.48, 1.691, 1.903, 2.114, 2.325, 2.537",\
+           "0, 0.3527, 0.7055, 1.058, 1.411, 1.764, 2.116, 2.469, 2.822, 3.175, 3.527, 3.88, 4.233",\
+           "0, 0.5387, 1.077, 1.616, 2.155, 2.694, 3.232, 3.771, 4.31, 4.849, 5.387, 5.926, 6.465",\
+           "0, 0.773, 1.546, 2.319, 3.092, 3.865, 4.638, 5.411, 6.184, 6.957, 7.73, 8.503, 9.276",\
+           "0, 1.059, 2.118, 3.177, 4.236, 5.295, 6.354, 7.413, 8.473, 9.532, 10.59, 11.65, 12.71",\
+           "0, 1.4, 2.8, 4.2, 5.6, 7, 8.4, 9.8, 11.2, 12.6, 14, 15.4, 16.8");
+  }
+}

--- a/liberty/gf180mcu_fd_sc_mcu9t5v0__ss_n40C_4v50.lib
+++ b/liberty/gf180mcu_fd_sc_mcu9t5v0__ss_n40C_4v50.lib
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 GlobalFoundries PDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+library(gf180mcu_fd_sc_mcu9t5v0__ss_n40C_4v50) { 
+  delay_model : table_lookup ; 
+  library_features(report_delay_calculation, report_power_calculation);
+  time_unit : 1ns ; 
+  voltage_unit : 1V ; 
+  current_unit : 1mA ; 
+  capacitive_load_unit(1, pf);
+  pulling_resistance_unit : 1ohm ; 
+  leakage_power_unit : 1uW ; 
+  input_threshold_pct_fall : 50 ; 
+  input_threshold_pct_rise : 50 ; 
+  output_threshold_pct_fall : 50 ; 
+  output_threshold_pct_rise : 50 ; 
+  slew_derate_from_library : 0.5 ; 
+  slew_lower_threshold_pct_fall : 30 ; 
+  slew_lower_threshold_pct_rise : 30 ; 
+  slew_upper_threshold_pct_fall : 70 ; 
+  slew_upper_threshold_pct_rise : 70 ; 
+  nom_process : 1 ; 
+  nom_temperature : -40 ; 
+  nom_voltage : 4.5 ; 
+  voltage_map(VNW, 4.5);
+  voltage_map(VDD, 4.5);
+  voltage_map(VSS, 0);
+  voltage_map(VPW, 0);
+
+  operating_conditions(gf180mcu_fd_sc_mcu9t5v0__ss_n40C_4v50) { 
+    process : 1 ; 
+    temperature : -40 ; 
+    voltage : 4.5 ; 
+  }
+
+  input_voltage(default) { 
+    vil : 0 ; 
+    vih : 4.5 ; 
+    vimin : 0 ; 
+    vimax : 4.5 ; 
+  }
+
+  output_voltage(default) { 
+    vol : 0 ; 
+    voh : 4.5 ; 
+    vomin : 0 ; 
+    vomax : 4.5 ; 
+  }
+
+  lu_table_template(cnst_ctin_rtin_10x10) { 
+    variable_1 : constrained_pin_transition ; 
+    variable_2 : related_pin_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(ndw_ntin_nvolt_10x13) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : normalized_voltage ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13");
+  }
+
+  lu_table_template(tmg_ntin_10) { 
+    variable_1 : input_net_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(tmg_ntin_oload_10x10) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_10) { 
+    variable_1 : input_transition_time ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_oload_10x10) { 
+    variable_1 : input_transition_time ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_fall" ; 
+    index_1("0.02, 0.05575, 0.1813, 0.4209, 0.7943, 1.318, 2.008, 2.876, 3.936, 5.2");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.006969, 0.01394, 0.02091, 0.02788, 0.03485, 0.04181, 0.04878, 0.05575, 0.06272, 0.06969, 0.07666, 0.08363",\
+           "0, 0.02266, 0.04531, 0.06797, 0.09063, 0.1133, 0.1359, 0.1586, 0.1813, 0.2039, 0.2266, 0.2492, 0.2719",\
+           "0, 0.05261, 0.1052, 0.1578, 0.2105, 0.2631, 0.3157, 0.3683, 0.4209, 0.4735, 0.5261, 0.5788, 0.6314",\
+           "0, 0.09929, 0.1986, 0.2979, 0.3971, 0.4964, 0.5957, 0.695, 0.7943, 0.8936, 0.9929, 1.092, 1.191",\
+           "0, 0.1648, 0.3295, 0.4943, 0.6591, 0.8239, 0.9886, 1.153, 1.318, 1.483, 1.648, 1.813, 1.977",\
+           "0, 0.2509, 0.5019, 0.7528, 1.004, 1.255, 1.506, 1.757, 2.008, 2.259, 2.509, 2.76, 3.011",\
+           "0, 0.3595, 0.719, 1.079, 1.438, 1.798, 2.157, 2.517, 2.876, 3.236, 3.595, 3.955, 4.314",\
+           "0, 0.492, 0.9841, 1.476, 1.968, 2.46, 2.952, 3.444, 3.936, 4.428, 4.92, 5.412, 5.904",\
+           "0, 0.65, 1.3, 1.95, 2.6, 3.25, 3.9, 4.55, 5.2, 5.85, 6.5, 7.15, 7.8");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_rise" ; 
+    index_1("0.02, 0.05575, 0.1813, 0.4209, 0.7943, 1.318, 2.008, 2.876, 3.936, 5.2");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.006969, 0.01394, 0.02091, 0.02788, 0.03485, 0.04181, 0.04878, 0.05575, 0.06272, 0.06969, 0.07666, 0.08363",\
+           "0, 0.02266, 0.04531, 0.06797, 0.09063, 0.1133, 0.1359, 0.1586, 0.1813, 0.2039, 0.2266, 0.2492, 0.2719",\
+           "0, 0.05261, 0.1052, 0.1578, 0.2105, 0.2631, 0.3157, 0.3683, 0.4209, 0.4735, 0.5261, 0.5788, 0.6314",\
+           "0, 0.09929, 0.1986, 0.2979, 0.3971, 0.4964, 0.5957, 0.695, 0.7943, 0.8936, 0.9929, 1.092, 1.191",\
+           "0, 0.1648, 0.3295, 0.4943, 0.6591, 0.8239, 0.9886, 1.153, 1.318, 1.483, 1.648, 1.813, 1.977",\
+           "0, 0.2509, 0.5019, 0.7528, 1.004, 1.255, 1.506, 1.757, 2.008, 2.259, 2.509, 2.76, 3.011",\
+           "0, 0.3595, 0.719, 1.079, 1.438, 1.798, 2.157, 2.517, 2.876, 3.236, 3.595, 3.955, 4.314",\
+           "0, 0.492, 0.9841, 1.476, 1.968, 2.46, 2.952, 3.444, 3.936, 4.428, 4.92, 5.412, 5.904",\
+           "0, 0.65, 1.3, 1.95, 2.6, 3.25, 3.9, 4.55, 5.2, 5.85, 6.5, 7.15, 7.8");
+  }
+}

--- a/liberty/gf180mcu_fd_sc_mcu9t5v0__tt_025C_1v80.lib
+++ b/liberty/gf180mcu_fd_sc_mcu9t5v0__tt_025C_1v80.lib
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 GlobalFoundries PDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+library(gf180mcu_fd_sc_mcu9t5v0__tt_025C_1v80) { 
+  delay_model : table_lookup ; 
+  library_features(report_delay_calculation, report_power_calculation);
+  time_unit : 1ns ; 
+  voltage_unit : 1V ; 
+  current_unit : 1mA ; 
+  capacitive_load_unit(1, pf);
+  pulling_resistance_unit : 1ohm ; 
+  leakage_power_unit : 1uW ; 
+  input_threshold_pct_fall : 50 ; 
+  input_threshold_pct_rise : 50 ; 
+  output_threshold_pct_fall : 50 ; 
+  output_threshold_pct_rise : 50 ; 
+  slew_derate_from_library : 0.5 ; 
+  slew_lower_threshold_pct_fall : 30 ; 
+  slew_lower_threshold_pct_rise : 30 ; 
+  slew_upper_threshold_pct_fall : 70 ; 
+  slew_upper_threshold_pct_rise : 70 ; 
+  nom_process : 1 ; 
+  nom_temperature : 25 ; 
+  nom_voltage : 1.8 ; 
+  voltage_map(VNW, 1.8);
+  voltage_map(VDD, 1.8);
+  voltage_map(VSS, 0);
+  voltage_map(VPW, 0);
+
+  operating_conditions(gf180mcu_fd_sc_mcu9t5v0__tt_025C_1v80) { 
+    process : 1 ; 
+    temperature : 25 ; 
+    voltage : 1.8 ; 
+  }
+
+  input_voltage(default) { 
+    vil : 0 ; 
+    vih : 1.8 ; 
+    vimin : 0 ; 
+    vimax : 1.8 ; 
+  }
+
+  output_voltage(default) { 
+    vol : 0 ; 
+    voh : 1.8 ; 
+    vomin : 0 ; 
+    vomax : 1.8 ; 
+  }
+
+  lu_table_template(cnst_ctin_rtin_10x10) { 
+    variable_1 : constrained_pin_transition ; 
+    variable_2 : related_pin_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(ndw_ntin_nvolt_10x13) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : normalized_voltage ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13");
+  }
+
+  lu_table_template(tmg_ntin_10) { 
+    variable_1 : input_net_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(tmg_ntin_oload_10x10) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_10) { 
+    variable_1 : input_transition_time ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_oload_10x10) { 
+    variable_1 : input_transition_time ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_fall" ; 
+    index_1("0.02, 0.1027, 0.3929, 0.9472, 1.811, 3.022, 4.617, 6.625, 9.077, 12");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.01284, 0.02567, 0.03851, 0.05134, 0.06418, 0.07702, 0.08985, 0.1027, 0.1155, 0.1284, 0.1412, 0.154",\
+           "0, 0.04912, 0.09823, 0.1474, 0.1965, 0.2456, 0.2947, 0.3438, 0.3929, 0.4421, 0.4912, 0.5403, 0.5894",\
+           "0, 0.1184, 0.2368, 0.3552, 0.4736, 0.592, 0.7104, 0.8288, 0.9472, 1.066, 1.184, 1.302, 1.421",\
+           "0, 0.2263, 0.4527, 0.679, 0.9054, 1.132, 1.358, 1.584, 1.811, 2.037, 2.263, 2.49, 2.716",\
+           "0, 0.3778, 0.7556, 1.133, 1.511, 1.889, 2.267, 2.645, 3.022, 3.4, 3.778, 4.156, 4.534",\
+           "0, 0.5771, 1.154, 1.731, 2.308, 2.885, 3.463, 4.04, 4.617, 5.194, 5.771, 6.348, 6.925",\
+           "0, 0.8282, 1.656, 2.485, 3.313, 4.141, 4.969, 5.797, 6.625, 7.454, 8.282, 9.11, 9.938",\
+           "0, 1.135, 2.269, 3.404, 4.539, 5.673, 6.808, 7.943, 9.077, 10.21, 11.35, 12.48, 13.62",\
+           "0, 1.5, 3, 4.5, 6, 7.5, 9, 10.5, 12, 13.5, 15, 16.5, 18");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_rise" ; 
+    index_1("0.02, 0.1027, 0.3929, 0.9472, 1.811, 3.022, 4.617, 6.625, 9.077, 12");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.01284, 0.02567, 0.03851, 0.05134, 0.06418, 0.07702, 0.08985, 0.1027, 0.1155, 0.1284, 0.1412, 0.154",\
+           "0, 0.04912, 0.09823, 0.1474, 0.1965, 0.2456, 0.2947, 0.3438, 0.3929, 0.4421, 0.4912, 0.5403, 0.5894",\
+           "0, 0.1184, 0.2368, 0.3552, 0.4736, 0.592, 0.7104, 0.8288, 0.9472, 1.066, 1.184, 1.302, 1.421",\
+           "0, 0.2263, 0.4527, 0.679, 0.9054, 1.132, 1.358, 1.584, 1.811, 2.037, 2.263, 2.49, 2.716",\
+           "0, 0.3778, 0.7556, 1.133, 1.511, 1.889, 2.267, 2.645, 3.022, 3.4, 3.778, 4.156, 4.534",\
+           "0, 0.5771, 1.154, 1.731, 2.308, 2.885, 3.463, 4.04, 4.617, 5.194, 5.771, 6.348, 6.925",\
+           "0, 0.8282, 1.656, 2.485, 3.313, 4.141, 4.969, 5.797, 6.625, 7.454, 8.282, 9.11, 9.938",\
+           "0, 1.135, 2.269, 3.404, 4.539, 5.673, 6.808, 7.943, 9.077, 10.21, 11.35, 12.48, 13.62",\
+           "0, 1.5, 3, 4.5, 6, 7.5, 9, 10.5, 12, 13.5, 15, 16.5, 18");
+  }
+}

--- a/liberty/gf180mcu_fd_sc_mcu9t5v0__tt_025C_3v30.lib
+++ b/liberty/gf180mcu_fd_sc_mcu9t5v0__tt_025C_3v30.lib
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 GlobalFoundries PDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+library(gf180mcu_fd_sc_mcu9t5v0__tt_025C_3v30) { 
+  delay_model : table_lookup ; 
+  library_features(report_delay_calculation, report_power_calculation);
+  time_unit : 1ns ; 
+  voltage_unit : 1V ; 
+  current_unit : 1mA ; 
+  capacitive_load_unit(1, pf);
+  pulling_resistance_unit : 1ohm ; 
+  leakage_power_unit : 1uW ; 
+  input_threshold_pct_fall : 50 ; 
+  input_threshold_pct_rise : 50 ; 
+  output_threshold_pct_fall : 50 ; 
+  output_threshold_pct_rise : 50 ; 
+  slew_derate_from_library : 0.5 ; 
+  slew_lower_threshold_pct_fall : 30 ; 
+  slew_lower_threshold_pct_rise : 30 ; 
+  slew_upper_threshold_pct_fall : 70 ; 
+  slew_upper_threshold_pct_rise : 70 ; 
+  nom_process : 1 ; 
+  nom_temperature : 25 ; 
+  nom_voltage : 3.3 ; 
+  voltage_map(VNW, 3.3);
+  voltage_map(VDD, 3.3);
+  voltage_map(VSS, 0);
+  voltage_map(VPW, 0);
+
+  operating_conditions(gf180mcu_fd_sc_mcu9t5v0__tt_025C_3v30) { 
+    process : 1 ; 
+    temperature : 25 ; 
+    voltage : 3.3 ; 
+  }
+
+  input_voltage(default) { 
+    vil : 0 ; 
+    vih : 3.3 ; 
+    vimin : 0 ; 
+    vimax : 3.3 ; 
+  }
+
+  output_voltage(default) { 
+    vol : 0 ; 
+    voh : 3.3 ; 
+    vomin : 0 ; 
+    vomax : 3.3 ; 
+  }
+
+  lu_table_template(cnst_ctin_rtin_10x10) { 
+    variable_1 : constrained_pin_transition ; 
+    variable_2 : related_pin_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(ndw_ntin_nvolt_10x13) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : normalized_voltage ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13");
+  }
+
+  lu_table_template(tmg_ntin_10) { 
+    variable_1 : input_net_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(tmg_ntin_oload_10x10) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_10) { 
+    variable_1 : input_transition_time ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_oload_10x10) { 
+    variable_1 : input_transition_time ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_fall" ; 
+    index_1("0.02, 0.06127, 0.2062, 0.4828, 0.9139, 1.519, 2.315, 3.317, 4.541, 6");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.007659, 0.01532, 0.02298, 0.03064, 0.0383, 0.04596, 0.05362, 0.06127, 0.06893, 0.07659, 0.08425, 0.09191",\
+           "0, 0.02577, 0.05154, 0.07731, 0.1031, 0.1288, 0.1546, 0.1804, 0.2062, 0.2319, 0.2577, 0.2835, 0.3092",\
+           "0, 0.06035, 0.1207, 0.1811, 0.2414, 0.3018, 0.3621, 0.4225, 0.4828, 0.5432, 0.6035, 0.6639, 0.7243",\
+           "0, 0.1142, 0.2285, 0.3427, 0.4569, 0.5712, 0.6854, 0.7996, 0.9139, 1.028, 1.142, 1.257, 1.371",\
+           "0, 0.1898, 0.3797, 0.5695, 0.7593, 0.9492, 1.139, 1.329, 1.519, 1.709, 1.898, 2.088, 2.278",\
+           "0, 0.2893, 0.5786, 0.868, 1.157, 1.447, 1.736, 2.025, 2.315, 2.604, 2.893, 3.182, 3.472",\
+           "0, 0.4146, 0.8293, 1.244, 1.659, 2.073, 2.488, 2.903, 3.317, 3.732, 4.146, 4.561, 4.976",\
+           "0, 0.5676, 1.135, 1.703, 2.271, 2.838, 3.406, 3.973, 4.541, 5.109, 5.676, 6.244, 6.812",\
+           "0, 0.75, 1.5, 2.25, 3, 3.75, 4.5, 5.25, 6, 6.75, 7.5, 8.25, 9");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_rise" ; 
+    index_1("0.02, 0.06127, 0.2062, 0.4828, 0.9139, 1.519, 2.315, 3.317, 4.541, 6");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.007659, 0.01532, 0.02298, 0.03064, 0.0383, 0.04596, 0.05362, 0.06127, 0.06893, 0.07659, 0.08425, 0.09191",\
+           "0, 0.02577, 0.05154, 0.07731, 0.1031, 0.1288, 0.1546, 0.1804, 0.2062, 0.2319, 0.2577, 0.2835, 0.3092",\
+           "0, 0.06035, 0.1207, 0.1811, 0.2414, 0.3018, 0.3621, 0.4225, 0.4828, 0.5432, 0.6035, 0.6639, 0.7243",\
+           "0, 0.1142, 0.2285, 0.3427, 0.4569, 0.5712, 0.6854, 0.7996, 0.9139, 1.028, 1.142, 1.257, 1.371",\
+           "0, 0.1898, 0.3797, 0.5695, 0.7593, 0.9492, 1.139, 1.329, 1.519, 1.709, 1.898, 2.088, 2.278",\
+           "0, 0.2893, 0.5786, 0.868, 1.157, 1.447, 1.736, 2.025, 2.315, 2.604, 2.893, 3.182, 3.472",\
+           "0, 0.4146, 0.8293, 1.244, 1.659, 2.073, 2.488, 2.903, 3.317, 3.732, 4.146, 4.561, 4.976",\
+           "0, 0.5676, 1.135, 1.703, 2.271, 2.838, 3.406, 3.973, 4.541, 5.109, 5.676, 6.244, 6.812",\
+           "0, 0.75, 1.5, 2.25, 3, 3.75, 4.5, 5.25, 6, 6.75, 7.5, 8.25, 9");
+  }
+}

--- a/liberty/gf180mcu_fd_sc_mcu9t5v0__tt_025C_5v00.lib
+++ b/liberty/gf180mcu_fd_sc_mcu9t5v0__tt_025C_5v00.lib
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 GlobalFoundries PDK Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+library(gf180mcu_fd_sc_mcu9t5v0__tt_025C_5v00) { 
+  delay_model : table_lookup ; 
+  library_features(report_delay_calculation, report_power_calculation);
+  time_unit : 1ns ; 
+  voltage_unit : 1V ; 
+  current_unit : 1mA ; 
+  capacitive_load_unit(1, pf);
+  pulling_resistance_unit : 1ohm ; 
+  leakage_power_unit : 1uW ; 
+  input_threshold_pct_fall : 50 ; 
+  input_threshold_pct_rise : 50 ; 
+  output_threshold_pct_fall : 50 ; 
+  output_threshold_pct_rise : 50 ; 
+  slew_derate_from_library : 0.5 ; 
+  slew_lower_threshold_pct_fall : 30 ; 
+  slew_lower_threshold_pct_rise : 30 ; 
+  slew_upper_threshold_pct_fall : 70 ; 
+  slew_upper_threshold_pct_rise : 70 ; 
+  nom_process : 1 ; 
+  nom_temperature : 25 ; 
+  nom_voltage : 5 ; 
+  voltage_map(VNW, 5);
+  voltage_map(VDD, 5);
+  voltage_map(VSS, 0);
+  voltage_map(VPW, 0);
+
+  operating_conditions(gf180mcu_fd_sc_mcu9t5v0__tt_025C_5v00) { 
+    process : 1 ; 
+    temperature : 25 ; 
+    voltage : 5 ; 
+  }
+
+  input_voltage(default) { 
+    vil : 0 ; 
+    vih : 5 ; 
+    vimin : 0 ; 
+    vimax : 5 ; 
+  }
+
+  output_voltage(default) { 
+    vol : 0 ; 
+    voh : 5 ; 
+    vomin : 0 ; 
+    vomax : 5 ; 
+  }
+
+  lu_table_template(cnst_ctin_rtin_10x10) { 
+    variable_1 : constrained_pin_transition ; 
+    variable_2 : related_pin_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(ndw_ntin_nvolt_10x13) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : normalized_voltage ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13");
+  }
+
+  lu_table_template(tmg_ntin_10) { 
+    variable_1 : input_net_transition ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  lu_table_template(tmg_ntin_oload_10x10) { 
+    variable_1 : input_net_transition ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_10) { 
+    variable_1 : input_transition_time ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  power_lut_template(pwr_tin_oload_10x10) { 
+    variable_1 : input_transition_time ; 
+    variable_2 : total_output_net_capacitance ; 
+    index_1("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+    index_2("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_fall" ; 
+    index_1("0.02, 0.04747, 0.1439, 0.328, 0.6149, 1.017, 1.547, 2.214, 3.029, 4");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.005934, 0.01187, 0.0178, 0.02374, 0.02967, 0.0356, 0.04154, 0.04747, 0.0534, 0.05934, 0.06527, 0.07121",\
+           "0, 0.01799, 0.03597, 0.05396, 0.07195, 0.08994, 0.1079, 0.1259, 0.1439, 0.1619, 0.1799, 0.1979, 0.2158",\
+           "0, 0.04101, 0.08201, 0.123, 0.164, 0.205, 0.246, 0.287, 0.328, 0.369, 0.4101, 0.4511, 0.4921",\
+           "0, 0.07687, 0.1537, 0.2306, 0.3075, 0.3843, 0.4612, 0.5381, 0.6149, 0.6918, 0.7687, 0.8455, 0.9224",\
+           "0, 0.1272, 0.2544, 0.3815, 0.5087, 0.6359, 0.7631, 0.8903, 1.017, 1.145, 1.272, 1.399, 1.526",\
+           "0, 0.1934, 0.3868, 0.5802, 0.7736, 0.967, 1.16, 1.354, 1.547, 1.741, 1.934, 2.127, 2.321",\
+           "0, 0.2768, 0.5536, 0.8304, 1.107, 1.384, 1.661, 1.938, 2.214, 2.491, 2.768, 3.045, 3.322",\
+           "0, 0.3786, 0.7573, 1.136, 1.515, 1.893, 2.272, 2.65, 3.029, 3.408, 3.786, 4.165, 4.544",\
+           "0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5, 5.5, 6");
+  }
+
+  normalized_driver_waveform(ndw_ntin_nvolt_10x13) { 
+    driver_waveform_name : "driver_waveform_default_rise" ; 
+    index_1("0.02, 0.04747, 0.1439, 0.328, 0.6149, 1.017, 1.547, 2.214, 3.029, 4");
+    index_2("0, 0.05, 0.1674, 0.3, 0.4168, 0.5209, 0.6146, 0.7, 0.7786, 0.8518, 0.9205, 0.9857, 1");
+    values("0, 0.0025, 0.005, 0.0075, 0.01, 0.0125, 0.015, 0.0175, 0.02, 0.0225, 0.025, 0.0275, 0.03",\
+           "0, 0.005934, 0.01187, 0.0178, 0.02374, 0.02967, 0.0356, 0.04154, 0.04747, 0.0534, 0.05934, 0.06527, 0.07121",\
+           "0, 0.01799, 0.03597, 0.05396, 0.07195, 0.08994, 0.1079, 0.1259, 0.1439, 0.1619, 0.1799, 0.1979, 0.2158",\
+           "0, 0.04101, 0.08201, 0.123, 0.164, 0.205, 0.246, 0.287, 0.328, 0.369, 0.4101, 0.4511, 0.4921",\
+           "0, 0.07687, 0.1537, 0.2306, 0.3075, 0.3843, 0.4612, 0.5381, 0.6149, 0.6918, 0.7687, 0.8455, 0.9224",\
+           "0, 0.1272, 0.2544, 0.3815, 0.5087, 0.6359, 0.7631, 0.8903, 1.017, 1.145, 1.272, 1.399, 1.526",\
+           "0, 0.1934, 0.3868, 0.5802, 0.7736, 0.967, 1.16, 1.354, 1.547, 1.741, 1.934, 2.127, 2.321",\
+           "0, 0.2768, 0.5536, 0.8304, 1.107, 1.384, 1.661, 1.938, 2.214, 2.491, 2.768, 3.045, 3.322",\
+           "0, 0.3786, 0.7573, 1.136, 1.515, 1.893, 2.272, 2.65, 3.029, 3.408, 3.786, 4.165, 4.544",\
+           "0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5, 5.5, 6");
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/google/gf180mcu-pdk/issues/65 (for the mcu9t5v0 standard cell library).
Adds the missing liberty file headers under the liberty/ directory.
The liberty libraries need to be reconstructed by inserting all the individual cell entries before the final closing brace.
Reconstruction of the library will presumably be done with a "make timing" step in the parent (gf180mcu-pdk) repository which has not yet been implemented.