### PR TITLE
wrap unwrapped attributes of test_cell of `ff(IQ1,IQN1)` in quotations

### DIFF
--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1__ff_125C_1v98.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1__ff_125C_1v98.lib
@@ -1844,8 +1844,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1__ff_125C_3v60.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1__ff_125C_3v60.lib
@@ -1844,8 +1844,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1__ff_125C_5v50.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1__ff_125C_5v50.lib
@@ -1844,8 +1844,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1__ff_n40C_1v98.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1__ff_n40C_1v98.lib
@@ -1844,8 +1844,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1__ff_n40C_3v60.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1__ff_n40C_3v60.lib
@@ -1844,8 +1844,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1__ff_n40C_5v50.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1__ff_n40C_5v50.lib
@@ -1844,8 +1844,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1__ss_125C_1v62.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1__ss_125C_1v62.lib
@@ -1829,8 +1829,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1__ss_125C_3v00.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1__ss_125C_3v00.lib
@@ -1829,8 +1829,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1__ss_125C_4v50.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1__ss_125C_4v50.lib
@@ -1829,8 +1829,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1__ss_n40C_1v62.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1__ss_n40C_1v62.lib
@@ -1829,8 +1829,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1__ss_n40C_3v00.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1__ss_n40C_3v00.lib
@@ -1829,8 +1829,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1__ss_n40C_4v50.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1__ss_n40C_4v50.lib
@@ -1829,8 +1829,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1__tt_025C_1v80.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1__tt_025C_1v80.lib
@@ -1829,8 +1829,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1__tt_025C_3v30.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1__tt_025C_3v30.lib
@@ -1829,8 +1829,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1__tt_025C_5v00.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_1__tt_025C_5v00.lib
@@ -1829,8 +1829,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2__ff_125C_1v98.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2__ff_125C_1v98.lib
@@ -1844,8 +1844,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2__ff_125C_3v60.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2__ff_125C_3v60.lib
@@ -1844,8 +1844,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2__ff_125C_5v50.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2__ff_125C_5v50.lib
@@ -1844,8 +1844,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2__ff_n40C_1v98.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2__ff_n40C_1v98.lib
@@ -1844,8 +1844,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2__ff_n40C_3v60.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2__ff_n40C_3v60.lib
@@ -1844,8 +1844,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2__ff_n40C_5v50.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2__ff_n40C_5v50.lib
@@ -1844,8 +1844,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2__ss_125C_1v62.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2__ss_125C_1v62.lib
@@ -1829,8 +1829,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2__ss_125C_3v00.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2__ss_125C_3v00.lib
@@ -1829,8 +1829,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2__ss_125C_4v50.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2__ss_125C_4v50.lib
@@ -1829,8 +1829,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2__ss_n40C_1v62.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2__ss_n40C_1v62.lib
@@ -1829,8 +1829,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2__ss_n40C_3v00.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2__ss_n40C_3v00.lib
@@ -1829,8 +1829,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2__ss_n40C_4v50.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2__ss_n40C_4v50.lib
@@ -1829,8 +1829,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2__tt_025C_1v80.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2__tt_025C_1v80.lib
@@ -1829,8 +1829,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2__tt_025C_3v30.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2__tt_025C_3v30.lib
@@ -1829,8 +1829,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2__tt_025C_5v00.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_2__tt_025C_5v00.lib
@@ -1829,8 +1829,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4__ff_125C_1v98.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4__ff_125C_1v98.lib
@@ -1844,8 +1844,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4__ff_125C_3v60.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4__ff_125C_3v60.lib
@@ -1844,8 +1844,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4__ff_125C_5v50.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4__ff_125C_5v50.lib
@@ -1844,8 +1844,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4__ff_n40C_1v98.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4__ff_n40C_1v98.lib
@@ -1844,8 +1844,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4__ff_n40C_3v60.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4__ff_n40C_3v60.lib
@@ -1844,8 +1844,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4__ff_n40C_5v50.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4__ff_n40C_5v50.lib
@@ -1844,8 +1844,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4__ss_125C_1v62.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4__ss_125C_1v62.lib
@@ -1829,8 +1829,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4__ss_125C_3v00.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4__ss_125C_3v00.lib
@@ -1829,8 +1829,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4__ss_125C_4v50.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4__ss_125C_4v50.lib
@@ -1829,8 +1829,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4__ss_n40C_1v62.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4__ss_n40C_1v62.lib
@@ -1829,8 +1829,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4__ss_n40C_3v00.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4__ss_n40C_3v00.lib
@@ -1829,8 +1829,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4__ss_n40C_4v50.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4__ss_n40C_4v50.lib
@@ -1829,8 +1829,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4__tt_025C_1v80.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4__tt_025C_1v80.lib
@@ -1829,8 +1829,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4__tt_025C_3v30.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4__tt_025C_3v30.lib
@@ -1829,8 +1829,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4__tt_025C_5v00.lib
+++ b/cells/sdffq/gf180mcu_fd_sc_mcu9t5v0__sdffq_4__tt_025C_5v00.lib
@@ -1829,8 +1829,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ff_125C_1v98.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ff_125C_1v98.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ff_125C_1v98.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ff_125C_1v98.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ff_125C_3v60.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ff_125C_3v60.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ff_125C_3v60.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ff_125C_3v60.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ff_125C_5v50.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ff_125C_5v50.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ff_125C_5v50.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ff_125C_5v50.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ff_n40C_1v98.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ff_n40C_1v98.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ff_n40C_1v98.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ff_n40C_1v98.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ff_n40C_3v60.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ff_n40C_3v60.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ff_n40C_3v60.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ff_n40C_3v60.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ff_n40C_5v50.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ff_n40C_5v50.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ff_n40C_5v50.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ff_n40C_5v50.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ss_125C_1v62.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ss_125C_1v62.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ss_125C_1v62.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ss_125C_1v62.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ss_125C_3v00.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ss_125C_3v00.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ss_125C_3v00.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ss_125C_3v00.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ss_125C_4v50.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ss_125C_4v50.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ss_125C_4v50.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ss_125C_4v50.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ss_n40C_1v62.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ss_n40C_1v62.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ss_n40C_1v62.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ss_n40C_1v62.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ss_n40C_3v00.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ss_n40C_3v00.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ss_n40C_3v00.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ss_n40C_3v00.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ss_n40C_4v50.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ss_n40C_4v50.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ss_n40C_4v50.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__ss_n40C_4v50.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__tt_025C_1v80.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__tt_025C_1v80.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__tt_025C_1v80.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__tt_025C_1v80.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__tt_025C_3v30.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__tt_025C_3v30.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__tt_025C_3v30.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__tt_025C_3v30.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__tt_025C_5v00.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__tt_025C_5v00.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__tt_025C_5v00.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_1__tt_025C_5v00.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ff_125C_1v98.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ff_125C_1v98.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ff_125C_1v98.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ff_125C_1v98.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ff_125C_3v60.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ff_125C_3v60.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ff_125C_3v60.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ff_125C_3v60.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ff_125C_5v50.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ff_125C_5v50.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ff_125C_5v50.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ff_125C_5v50.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ff_n40C_1v98.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ff_n40C_1v98.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ff_n40C_1v98.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ff_n40C_1v98.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ff_n40C_3v60.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ff_n40C_3v60.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ff_n40C_3v60.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ff_n40C_3v60.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ff_n40C_5v50.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ff_n40C_5v50.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ff_n40C_5v50.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ff_n40C_5v50.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ss_125C_1v62.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ss_125C_1v62.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ss_125C_1v62.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ss_125C_1v62.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ss_125C_3v00.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ss_125C_3v00.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ss_125C_3v00.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ss_125C_3v00.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ss_125C_4v50.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ss_125C_4v50.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ss_125C_4v50.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ss_125C_4v50.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ss_n40C_1v62.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ss_n40C_1v62.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ss_n40C_1v62.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ss_n40C_1v62.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ss_n40C_3v00.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ss_n40C_3v00.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ss_n40C_3v00.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ss_n40C_3v00.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ss_n40C_4v50.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ss_n40C_4v50.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ss_n40C_4v50.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__ss_n40C_4v50.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__tt_025C_1v80.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__tt_025C_1v80.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__tt_025C_1v80.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__tt_025C_1v80.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__tt_025C_3v30.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__tt_025C_3v30.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__tt_025C_3v30.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__tt_025C_3v30.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__tt_025C_5v00.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__tt_025C_5v00.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__tt_025C_5v00.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_2__tt_025C_5v00.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ff_125C_1v98.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ff_125C_1v98.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ff_125C_1v98.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ff_125C_1v98.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ff_125C_3v60.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ff_125C_3v60.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ff_125C_3v60.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ff_125C_3v60.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ff_125C_5v50.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ff_125C_5v50.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ff_125C_5v50.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ff_125C_5v50.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ff_n40C_1v98.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ff_n40C_1v98.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ff_n40C_1v98.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ff_n40C_1v98.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ff_n40C_3v60.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ff_n40C_3v60.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ff_n40C_3v60.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ff_n40C_3v60.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ff_n40C_5v50.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ff_n40C_5v50.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ff_n40C_5v50.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ff_n40C_5v50.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ss_125C_1v62.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ss_125C_1v62.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ss_125C_1v62.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ss_125C_1v62.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ss_125C_3v00.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ss_125C_3v00.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ss_125C_3v00.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ss_125C_3v00.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ss_125C_4v50.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ss_125C_4v50.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ss_125C_4v50.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ss_125C_4v50.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ss_n40C_1v62.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ss_n40C_1v62.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ss_n40C_1v62.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ss_n40C_1v62.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ss_n40C_3v00.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ss_n40C_3v00.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ss_n40C_3v00.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ss_n40C_3v00.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ss_n40C_4v50.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ss_n40C_4v50.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ss_n40C_4v50.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__ss_n40C_4v50.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__tt_025C_1v80.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__tt_025C_1v80.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__tt_025C_1v80.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__tt_025C_1v80.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__tt_025C_3v30.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__tt_025C_3v30.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__tt_025C_3v30.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__tt_025C_3v30.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__tt_025C_5v00.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__tt_025C_5v00.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
+        clear : "!RN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__tt_025C_5v00.lib
+++ b/cells/sdffrnq/gf180mcu_fd_sc_mcu9t5v0__sdffrnq_4__tt_025C_5v00.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
       }
 

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ff_125C_1v98.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ff_125C_1v98.lib
@@ -10702,8 +10702,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ff_125C_1v98.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ff_125C_1v98.lib
@@ -10704,8 +10704,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ff_125C_3v60.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ff_125C_3v60.lib
@@ -10702,8 +10702,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ff_125C_3v60.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ff_125C_3v60.lib
@@ -10704,8 +10704,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ff_125C_5v50.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ff_125C_5v50.lib
@@ -10702,8 +10702,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ff_125C_5v50.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ff_125C_5v50.lib
@@ -10704,8 +10704,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ff_n40C_1v98.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ff_n40C_1v98.lib
@@ -10702,8 +10702,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ff_n40C_1v98.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ff_n40C_1v98.lib
@@ -10704,8 +10704,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ff_n40C_3v60.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ff_n40C_3v60.lib
@@ -10702,8 +10702,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ff_n40C_3v60.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ff_n40C_3v60.lib
@@ -10704,8 +10704,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ff_n40C_5v50.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ff_n40C_5v50.lib
@@ -10702,8 +10702,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ff_n40C_5v50.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ff_n40C_5v50.lib
@@ -10704,8 +10704,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ss_125C_1v62.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ss_125C_1v62.lib
@@ -10687,8 +10687,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ss_125C_1v62.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ss_125C_1v62.lib
@@ -10689,8 +10689,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ss_125C_3v00.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ss_125C_3v00.lib
@@ -10687,8 +10687,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ss_125C_3v00.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ss_125C_3v00.lib
@@ -10689,8 +10689,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ss_125C_4v50.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ss_125C_4v50.lib
@@ -10687,8 +10687,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ss_125C_4v50.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ss_125C_4v50.lib
@@ -10689,8 +10689,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ss_n40C_1v62.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ss_n40C_1v62.lib
@@ -10687,8 +10687,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ss_n40C_1v62.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ss_n40C_1v62.lib
@@ -10689,8 +10689,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ss_n40C_3v00.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ss_n40C_3v00.lib
@@ -10687,8 +10687,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ss_n40C_3v00.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ss_n40C_3v00.lib
@@ -10689,8 +10689,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ss_n40C_4v50.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ss_n40C_4v50.lib
@@ -10687,8 +10687,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ss_n40C_4v50.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__ss_n40C_4v50.lib
@@ -10689,8 +10689,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__tt_025C_1v80.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__tt_025C_1v80.lib
@@ -10687,8 +10687,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__tt_025C_1v80.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__tt_025C_1v80.lib
@@ -10689,8 +10689,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__tt_025C_3v30.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__tt_025C_3v30.lib
@@ -10687,8 +10687,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__tt_025C_3v30.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__tt_025C_3v30.lib
@@ -10689,8 +10689,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__tt_025C_5v00.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__tt_025C_5v00.lib
@@ -10687,8 +10687,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__tt_025C_5v00.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_1__tt_025C_5v00.lib
@@ -10689,8 +10689,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ff_125C_1v98.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ff_125C_1v98.lib
@@ -10702,8 +10702,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ff_125C_1v98.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ff_125C_1v98.lib
@@ -10704,8 +10704,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ff_125C_3v60.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ff_125C_3v60.lib
@@ -10702,8 +10702,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ff_125C_3v60.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ff_125C_3v60.lib
@@ -10704,8 +10704,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ff_125C_5v50.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ff_125C_5v50.lib
@@ -10702,8 +10702,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ff_125C_5v50.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ff_125C_5v50.lib
@@ -10704,8 +10704,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ff_n40C_1v98.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ff_n40C_1v98.lib
@@ -10702,8 +10702,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ff_n40C_1v98.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ff_n40C_1v98.lib
@@ -10704,8 +10704,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ff_n40C_3v60.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ff_n40C_3v60.lib
@@ -10702,8 +10702,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ff_n40C_3v60.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ff_n40C_3v60.lib
@@ -10704,8 +10704,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ff_n40C_5v50.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ff_n40C_5v50.lib
@@ -10702,8 +10702,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ff_n40C_5v50.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ff_n40C_5v50.lib
@@ -10704,8 +10704,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ss_125C_1v62.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ss_125C_1v62.lib
@@ -10687,8 +10687,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ss_125C_1v62.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ss_125C_1v62.lib
@@ -10689,8 +10689,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ss_125C_3v00.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ss_125C_3v00.lib
@@ -10687,8 +10687,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ss_125C_3v00.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ss_125C_3v00.lib
@@ -10689,8 +10689,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ss_125C_4v50.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ss_125C_4v50.lib
@@ -10687,8 +10687,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ss_125C_4v50.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ss_125C_4v50.lib
@@ -10689,8 +10689,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ss_n40C_1v62.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ss_n40C_1v62.lib
@@ -10687,8 +10687,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ss_n40C_1v62.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ss_n40C_1v62.lib
@@ -10689,8 +10689,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ss_n40C_3v00.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ss_n40C_3v00.lib
@@ -10687,8 +10687,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ss_n40C_3v00.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ss_n40C_3v00.lib
@@ -10689,8 +10689,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ss_n40C_4v50.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ss_n40C_4v50.lib
@@ -10687,8 +10687,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ss_n40C_4v50.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__ss_n40C_4v50.lib
@@ -10689,8 +10689,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__tt_025C_1v80.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__tt_025C_1v80.lib
@@ -10687,8 +10687,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__tt_025C_1v80.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__tt_025C_1v80.lib
@@ -10689,8 +10689,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__tt_025C_3v30.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__tt_025C_3v30.lib
@@ -10687,8 +10687,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__tt_025C_3v30.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__tt_025C_3v30.lib
@@ -10689,8 +10689,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__tt_025C_5v00.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__tt_025C_5v00.lib
@@ -10687,8 +10687,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__tt_025C_5v00.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_2__tt_025C_5v00.lib
@@ -10689,8 +10689,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ff_125C_1v98.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ff_125C_1v98.lib
@@ -10702,8 +10702,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ff_125C_1v98.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ff_125C_1v98.lib
@@ -10704,8 +10704,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ff_125C_3v60.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ff_125C_3v60.lib
@@ -10702,8 +10702,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ff_125C_3v60.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ff_125C_3v60.lib
@@ -10704,8 +10704,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ff_125C_5v50.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ff_125C_5v50.lib
@@ -10702,8 +10702,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ff_125C_5v50.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ff_125C_5v50.lib
@@ -10704,8 +10704,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ff_n40C_1v98.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ff_n40C_1v98.lib
@@ -10702,8 +10702,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ff_n40C_1v98.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ff_n40C_1v98.lib
@@ -10704,8 +10704,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ff_n40C_3v60.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ff_n40C_3v60.lib
@@ -10702,8 +10702,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ff_n40C_3v60.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ff_n40C_3v60.lib
@@ -10704,8 +10704,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ff_n40C_5v50.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ff_n40C_5v50.lib
@@ -10702,8 +10702,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ff_n40C_5v50.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ff_n40C_5v50.lib
@@ -10704,8 +10704,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ss_125C_1v62.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ss_125C_1v62.lib
@@ -10687,8 +10687,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ss_125C_1v62.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ss_125C_1v62.lib
@@ -10689,8 +10689,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ss_125C_3v00.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ss_125C_3v00.lib
@@ -10687,8 +10687,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ss_125C_3v00.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ss_125C_3v00.lib
@@ -10689,8 +10689,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ss_125C_4v50.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ss_125C_4v50.lib
@@ -10687,8 +10687,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ss_125C_4v50.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ss_125C_4v50.lib
@@ -10689,8 +10689,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ss_n40C_1v62.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ss_n40C_1v62.lib
@@ -10687,8 +10687,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ss_n40C_1v62.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ss_n40C_1v62.lib
@@ -10689,8 +10689,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ss_n40C_3v00.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ss_n40C_3v00.lib
@@ -10687,8 +10687,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ss_n40C_3v00.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ss_n40C_3v00.lib
@@ -10689,8 +10689,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ss_n40C_4v50.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ss_n40C_4v50.lib
@@ -10687,8 +10687,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ss_n40C_4v50.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__ss_n40C_4v50.lib
@@ -10689,8 +10689,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__tt_025C_1v80.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__tt_025C_1v80.lib
@@ -10687,8 +10687,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__tt_025C_1v80.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__tt_025C_1v80.lib
@@ -10689,8 +10689,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__tt_025C_3v30.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__tt_025C_3v30.lib
@@ -10687,8 +10687,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__tt_025C_3v30.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__tt_025C_3v30.lib
@@ -10689,8 +10689,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__tt_025C_5v00.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__tt_025C_5v00.lib
@@ -10687,8 +10687,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         clear : "!RN" ;
         preset : "!SETN" ;
         clear_preset_var1 : L ;

--- a/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__tt_025C_5v00.lib
+++ b/cells/sdffrsnq/gf180mcu_fd_sc_mcu9t5v0__sdffrsnq_4__tt_025C_5v00.lib
@@ -10689,8 +10689,8 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        clear : !RN ;
-        preset : !SETN ;
+        clear : "!RN" ;
+        preset : "!SETN" ;
         clear_preset_var1 : L ;
         clear_preset_var2 : H ;
       }

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ff_125C_1v98.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ff_125C_1v98.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ff_125C_1v98.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ff_125C_1v98.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ff_125C_3v60.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ff_125C_3v60.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ff_125C_3v60.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ff_125C_3v60.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ff_125C_5v50.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ff_125C_5v50.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ff_125C_5v50.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ff_125C_5v50.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ff_n40C_1v98.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ff_n40C_1v98.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ff_n40C_1v98.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ff_n40C_1v98.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ff_n40C_3v60.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ff_n40C_3v60.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ff_n40C_3v60.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ff_n40C_3v60.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ff_n40C_5v50.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ff_n40C_5v50.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ff_n40C_5v50.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ff_n40C_5v50.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ss_125C_1v62.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ss_125C_1v62.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ss_125C_1v62.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ss_125C_1v62.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ss_125C_3v00.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ss_125C_3v00.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ss_125C_3v00.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ss_125C_3v00.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ss_125C_4v50.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ss_125C_4v50.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ss_125C_4v50.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ss_125C_4v50.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ss_n40C_1v62.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ss_n40C_1v62.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ss_n40C_1v62.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ss_n40C_1v62.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ss_n40C_3v00.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ss_n40C_3v00.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ss_n40C_3v00.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ss_n40C_3v00.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ss_n40C_4v50.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ss_n40C_4v50.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ss_n40C_4v50.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__ss_n40C_4v50.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__tt_025C_1v80.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__tt_025C_1v80.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__tt_025C_1v80.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__tt_025C_1v80.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__tt_025C_3v30.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__tt_025C_3v30.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__tt_025C_3v30.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__tt_025C_3v30.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__tt_025C_5v00.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__tt_025C_5v00.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__tt_025C_5v00.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_1__tt_025C_5v00.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ff_125C_1v98.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ff_125C_1v98.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ff_125C_1v98.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ff_125C_1v98.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ff_125C_3v60.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ff_125C_3v60.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ff_125C_3v60.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ff_125C_3v60.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ff_125C_5v50.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ff_125C_5v50.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ff_125C_5v50.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ff_125C_5v50.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ff_n40C_1v98.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ff_n40C_1v98.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ff_n40C_1v98.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ff_n40C_1v98.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ff_n40C_3v60.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ff_n40C_3v60.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ff_n40C_3v60.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ff_n40C_3v60.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ff_n40C_5v50.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ff_n40C_5v50.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ff_n40C_5v50.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ff_n40C_5v50.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ss_125C_1v62.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ss_125C_1v62.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ss_125C_1v62.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ss_125C_1v62.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ss_125C_3v00.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ss_125C_3v00.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ss_125C_3v00.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ss_125C_3v00.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ss_125C_4v50.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ss_125C_4v50.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ss_125C_4v50.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ss_125C_4v50.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ss_n40C_1v62.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ss_n40C_1v62.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ss_n40C_1v62.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ss_n40C_1v62.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ss_n40C_3v00.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ss_n40C_3v00.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ss_n40C_3v00.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ss_n40C_3v00.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ss_n40C_4v50.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ss_n40C_4v50.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ss_n40C_4v50.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__ss_n40C_4v50.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__tt_025C_1v80.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__tt_025C_1v80.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__tt_025C_1v80.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__tt_025C_1v80.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__tt_025C_3v30.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__tt_025C_3v30.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__tt_025C_3v30.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__tt_025C_3v30.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__tt_025C_5v00.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__tt_025C_5v00.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__tt_025C_5v00.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_2__tt_025C_5v00.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ff_125C_1v98.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ff_125C_1v98.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ff_125C_1v98.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ff_125C_1v98.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ff_125C_3v60.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ff_125C_3v60.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ff_125C_3v60.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ff_125C_3v60.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ff_125C_5v50.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ff_125C_5v50.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ff_125C_5v50.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ff_125C_5v50.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ff_n40C_1v98.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ff_n40C_1v98.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ff_n40C_1v98.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ff_n40C_1v98.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ff_n40C_3v60.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ff_n40C_3v60.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ff_n40C_3v60.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ff_n40C_3v60.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ff_n40C_5v50.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ff_n40C_5v50.lib
@@ -4297,8 +4297,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ff_n40C_5v50.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ff_n40C_5v50.lib
@@ -4299,7 +4299,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ss_125C_1v62.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ss_125C_1v62.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ss_125C_1v62.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ss_125C_1v62.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ss_125C_3v00.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ss_125C_3v00.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ss_125C_3v00.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ss_125C_3v00.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ss_125C_4v50.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ss_125C_4v50.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ss_125C_4v50.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ss_125C_4v50.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ss_n40C_1v62.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ss_n40C_1v62.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ss_n40C_1v62.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ss_n40C_1v62.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ss_n40C_3v00.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ss_n40C_3v00.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ss_n40C_3v00.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ss_n40C_3v00.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ss_n40C_4v50.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ss_n40C_4v50.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ss_n40C_4v50.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__ss_n40C_4v50.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__tt_025C_1v80.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__tt_025C_1v80.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__tt_025C_1v80.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__tt_025C_1v80.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__tt_025C_3v30.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__tt_025C_3v30.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__tt_025C_3v30.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__tt_025C_3v30.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__tt_025C_5v00.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__tt_025C_5v00.lib
@@ -4284,7 +4284,7 @@
       ff(IQ1,IQN1) {
         clocked_on : CLK ;
         next_state : D ;
-        preset : !SETN ;
+        preset : "!SETN" ;
       }
 
       pin(CLK) {

--- a/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__tt_025C_5v00.lib
+++ b/cells/sdffsnq/gf180mcu_fd_sc_mcu9t5v0__sdffsnq_4__tt_025C_5v00.lib
@@ -4282,8 +4282,8 @@
       }
 
       ff(IQ1,IQN1) {
-        clocked_on : CLK ;
-        next_state : D ;
+        clocked_on : "CLK" ;
+        next_state : "D" ;
         preset : "!SETN" ;
       }
 


### PR DESCRIPTION
Fixes https://github.com/google/globalfoundries-pdk-libs-gf180mcu_fd_sc_mcu9t5v0/issues/21

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR