### PR TITLE
Fix incorrectly modified values in LEF.

### DIFF
--- a/cells/antenna/gf180mcu_fd_sc_mcu9t5v0__antenna.lef
+++ b/cells/antenna/gf180mcu_fd_sc_mcu9t5v0__antenna.lef
@@ -21,7 +21,7 @@ MACRO gf180mcu_fd_sc_mcu9t5v0__antenna
   SIZE 1.12 BY 5.04 ;
   PIN I
     DIRECTION INPUT ;
-    gf180mcu_fd_sc_mcu9t5v0__antennaDIFFAREA 0.4068 ;
+    ANTENNADIFFAREA 0.4068 ;
     PORT
       LAYER Metal1 ;
         POLYGON 0.15 1.315 0.475 1.315 0.475 3.215 0.15 3.215  ;

--- a/cells/antenna/gf180mcu_fd_sc_mcu9t5v0__antenna.lef
+++ b/cells/antenna/gf180mcu_fd_sc_mcu9t5v0__antenna.lef
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 MACRO gf180mcu_fd_sc_mcu9t5v0__antenna
-  CLASS core gf180mcu_fd_sc_mcu9t5v0__antennaCELL ;
+  CLASS core ANTENNACELL ;
   FOREIGN gf180mcu_fd_sc_mcu9t5v0__antenna 0.0 0.0 ;
   ORIGIN 0 0 ;
   SYMMETRY X Y ;

--- a/cells/endcap/gf180mcu_fd_sc_mcu9t5v0__endcap.lef
+++ b/cells/endcap/gf180mcu_fd_sc_mcu9t5v0__endcap.lef
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 MACRO gf180mcu_fd_sc_mcu9t5v0__endcap
-  CLASS gf180mcu_fd_sc_mcu9t5v0__endcap PRE ;
+  CLASS ENDCAP PRE ;
   FOREIGN gf180mcu_fd_sc_mcu9t5v0__endcap 0.0 0.0 ;
   ORIGIN 0 0 ;
   SYMMETRY X Y ;

--- a/cells/tieh/gf180mcu_fd_sc_mcu9t5v0__tieh.lef
+++ b/cells/tieh/gf180mcu_fd_sc_mcu9t5v0__tieh.lef
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 MACRO gf180mcu_fd_sc_mcu9t5v0__tieh
-  CLASS core gf180mcu_fd_sc_mcu9t5v0__tiehIGH ;
+  CLASS core TIEHIGH ;
   FOREIGN gf180mcu_fd_sc_mcu9t5v0__tieh 0.0 0.0 ;
   ORIGIN 0 0 ;
   SYMMETRY X Y ;

--- a/cells/tiel/gf180mcu_fd_sc_mcu9t5v0__tiel.lef
+++ b/cells/tiel/gf180mcu_fd_sc_mcu9t5v0__tiel.lef
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 MACRO gf180mcu_fd_sc_mcu9t5v0__tiel
-  CLASS core gf180mcu_fd_sc_mcu9t5v0__tielOW ;
+  CLASS core TIELOW ;
   FOREIGN gf180mcu_fd_sc_mcu9t5v0__tiel 0.0 0.0 ;
   ORIGIN 0 0 ;
   SYMMETRY X Y ;


### PR DESCRIPTION
 * Fix the `class` values in `antenna`, `endcap`, `tieh`, & `tiel` cells.
 * Fix the `ANTENNADIFFAREA` in the `antenna` cell.

Fixes https://github.com/google/gf180mcu-pdk/issues/104 and https://github.com/google/gf180mcu-pdk/issues/106